### PR TITLE
Update devcontainer to install package

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     // "forwardPorts": [],
 
     // Use 'postCreateCommand' to run commands after the container is created.
-    // "postCreateCommand": "pip3 install --user -r requirements.txt",
+    "postCreateCommand": "sh .devcontainer/post-create.sh",
 
     // Configure tool-specific properties.
     // "customizations": {},
@@ -21,5 +21,14 @@
     // "remoteUser": "root"
 
     // Added to resolve Dubios Ownership. More info: https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/#:~:text=How%20do%20I%20fix%20it,%2D%2Dglobal%20%2D%2Dadd%20safe.
-    "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+    "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {},
+            "extensions": ["mike-lischke.vscode-antlr4", "ms-python.mypy-type-checker", "charliermarsh.ruff"]
+        }
+    }
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Intall JRE for the ANTLRv4 tools
+sudo apt update --assume-yes
+sudo apt upgrade --assume-yes
+sudo apt install default-jre --assume-yes
+
+# Upgrade pip
+pip install --upgrade pip
+
+# Install the package
+pip install --user --editable ".[dev]"
+
+# Install pre-commit
+pre-commit install

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.antlr
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 ## Developer Setup
 
+There are two options here: `vscode` _devcontainer_ (preferred) and local using a virtual environment.
+
+### Docker Container
+
+This option requires `docker`, `vscode`, and the vscode _Dev Containers_ extension. The `devcontainer` is defined in the `.devcontainer/devcontainer.json` file that includes _customizations_ to install various `vscode` extensions in the `devcontainer` and a call to install additional packages on the image after creation. The post-create actions are defined in the `.devcontainer/post-create.sh` script. It configures the full development environment so there are no further actions required after the image is created.
+
+Open the directory to use the container: `code -n bpmn_cwp_verify`. The `vscode` _Dev Containers_ extension should automatically recognize the presence of a `devcontainer` and prompt to reopen in the container. If the extension doesn't recognize the container, then open the command pallette and search for `Dev Containers: Reopen in Container`.
+
+If the `pyproject.toml` file is changed to add new dependencies etc, then the container will need to be rebuilt: `Dev Containers: Rebuild container` (slow). It should also be possible to just reinstall the project to get the new dependencies (fast): `pip install --editable ".[dev]"`.
+
+### Local Install
+
 The following assume the terminal is in the root directory of the package.
 
   1. Create a virtual environment
@@ -17,10 +29,6 @@ The following assume the terminal is in the root directory of the package.
   The package uses `setuptools` and is configured in `pyproject.toml`. If a new dependency is required (added), then please update the `pyproject.toml` file accordingly so that the install brings it down as expected. All of the `pre-commit` hooks are defined in the `.pre-commit-config.yaml`. Please update as needed. It currently uses `ruff` for linting and formatting. It uses `mypy` for static typechecking.
 
   If using the `mypy` vscode extension, then it is necessary to point the executable path to `.venv/bin/dmypy` for it to work correctly.
-
-### Docker Container
-
-There is an available container that `vscode` is able to recognize and open. In the command pallette `Python: create virtual environment` will create the virtual environment, and it will install the `dev` dependencies automatically as part of the configuration.
 
 ## Generating ANTLR Stuff
 

--- a/antlr/State.g4
+++ b/antlr/State.g4
@@ -4,12 +4,12 @@ state
   : (enum_type_decl)* (const_var_decl)* (var_decl)+ EOF
   ;
 
-const_var_decl
-  : CONST ID COLON ID EQUALS ID
-  ;
-
 enum_type_decl
   : ENUM ID LCURLY (ID)+ RCURLY
+  ;
+
+const_var_decl
+  : CONST ID COLON ID EQUALS ID
   ;
 
 var_decl


### PR DESCRIPTION
The `devcontainer` now installs useful `vscode` extensions, and it installs the package with all if its dependencies. As such once the container is built, no further actions are required to start developing.