### PR TITLE
Add SPIN to container with Promela vscode ext

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
         "vscode": {
             // Set *default* container specific settings.json values on container create.
             "settings": {},
-            "extensions": ["mike-lischke.vscode-antlr4", "ms-python.mypy-type-checker", "charliermarsh.ruff"]
+            "extensions": ["mike-lischke.vscode-antlr4", "ms-python.mypy-type-checker", "charliermarsh.ruff", "peacekeeper228.spin-promela"]
         }
     }
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,6 +5,7 @@ sudo apt update --assume-yes
 sudo apt upgrade --assume-yes
 sudo apt install default-jre --assume-yes
 sudo apt install graphviz --assume-yes
+sudo apt install spin --assume-yes
 
 # Upgrade pip
 pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,7 @@ cython_debug/
 
 .antlr
 .vscode
+
+# SPIN Artifacts
+pan
+*.trail


### PR DESCRIPTION
Add SPIN to the `post-create.sh` to install it into the container.

Add the Promela vscode extension to the `devcontainer.json` definition.

Add `pan` and `*.trail` to the `.gitignore` to keep status checks quiet.