### PR TITLE
Add literal typing to SymbolTable.get_type

### DIFF
--- a/src/bpmncwpverify/error.py
+++ b/src/bpmncwpverify/error.py
@@ -78,14 +78,6 @@ class StateSyntaxError(Error):
         super().__init__()
 
 
-class StateUnknownTypeError(Error):
-    __slots__ = "id"
-
-    def __init__(self, id: str) -> None:
-        super().__init__()
-        self.id = id
-
-
 class TypingAssignCompatabilityError(Error):
     __slots__ = ["ltype", "rtype"]
 
@@ -140,8 +132,6 @@ def _get_error_message(error: Error) -> str:
             )
         case StateSyntaxError(msg=msg):
             return "STATE SYNTAX ERROR: {}".format(msg)
-        case StateUnknownTypeError(id=id):
-            return "STATE ERROR: the type of '{}' is not known".format(id)
         case TypingAssignCompatabilityError(ltype=ltype, rtype=rtype):
             return "TYPING ERROR: something of type '{}' cannot by assigned to something of type '{}'".format(
                 rtype, ltype

--- a/test/test_error.py
+++ b/test/test_error.py
@@ -7,7 +7,6 @@ from bpmncwpverify.error import (
     StateInitNotInValues,
     StateMultipleDefinitionError,
     StateSyntaxError,
-    StateUnknownTypeError,
     TypingAssignCompatabilityError,
     TypingNoTypeError,
     get_error_message,
@@ -24,7 +23,6 @@ test_inputs: list[tuple[Error, str]] = [
         "STATE ERROR: multiple definition of 'a' at line 42:43, previously defined at line 0:1",
     ),
     (StateSyntaxError("bad syntax"), "STATE SYNTAX ERROR: bad syntax"),
-    (StateUnknownTypeError("a"), "STATE ERROR: the type of 'a' is not known"),
     (
         TypingAssignCompatabilityError("enum", "int"),
         "TYPING ERROR: something of type 'int' cannot by assigned to something of type 'enum'",
@@ -36,7 +34,6 @@ test_ids: list[str] = [
     "StateInitNotInValues",
     "StateMultipleDefinitionError",
     "StateSyntaxError",
-    "StateUnknownTypeError",
     "TypeingAssignCompatabilityError",
     "TypingNoTypeError",
 ]


### PR DESCRIPTION
* Expand the `SymbolTable.get_type` interface to return type information for literals
* Remove the `StateUnknownType` error and replace it with `TypingNoTypeError`.
