### PR TITLE
Update Cwp builder, bpmn and expression checker

### DIFF
--- a/src/bpmncwpverify/builder/cwp_builder.py
+++ b/src/bpmncwpverify/builder/cwp_builder.py
@@ -10,7 +10,7 @@ from returns.pipeline import is_successful
 from returns.functions import not_
 
 
-class ConcreteCwpBuilder:
+class CwpBuilder:
     def __init__(self, symbol_table: SymbolTable) -> None:
         self.edges: List[Element] = []
         self.all_items: List[Element] = []
@@ -62,8 +62,8 @@ class ConcreteCwpBuilder:
                 if not edge or not (parent_id_ref := mx_cell.get("id")):
                     raise Exception("Parent edge not found or no parent ID reference")
 
-                edge.expression = edge.cleanup_expression(expression)
-                result = expr_checker.build(edge.expression, self.symbol_table)
+                edge.expression = expression
+                result = expr_checker.type_check(edge.expression, self.symbol_table)
                 if not_(is_successful)(result):
                     raise Exception(result)
 

--- a/src/bpmncwpverify/core/bpmn.py
+++ b/src/bpmncwpverify/core/bpmn.py
@@ -1,6 +1,7 @@
-from typing import List, Dict, Type, Union
+from typing import List, Dict, Union
 from xml.etree.ElementTree import Element
-from returns.result import Failure, Result, Success
+from bpmncwpverify.core.state import SymbolTable
+from returns.result import Failure, Result
 from defusedxml.ElementTree import parse
 from bpmncwpverify.constants import NAMESPACES
 from bpmncwpverify.error import (
@@ -21,7 +22,7 @@ class BpmnElement:
 
         self.id = id
 
-        self.name = element.attrib.get("name", self.id)
+        self.name: str = element.attrib.get("name", self.id)
 
 
 ###################
@@ -30,6 +31,19 @@ class BpmnElement:
 class Node(BpmnElement):
     def __init__(self, element: Element) -> None:
         super().__init__(element)
+
+        message_event_def = element.find("bpmn:messageEventDefinition", NAMESPACES)
+        self.message_event_definition: str = (
+            message_event_def.attrib.get("id", "")
+            if message_event_def is not None
+            else ""
+        )
+
+        timer_event_def = element.find("bpmn:timerEventDefinition", NAMESPACES)
+        self.message_timer_definition: str = (
+            timer_event_def.attrib.get("id", "") if timer_event_def is not None else ""
+        )
+
         self.out_flows: List[SequenceFlow] = []
         self.in_flows: List[SequenceFlow] = []
         self.in_msgs: List[MessageFlow] = []
@@ -175,10 +189,10 @@ class Flow(BpmnElement):
 class SequenceFlow(Flow):
     def __init__(self, element: Element):
         super().__init__(element)
+        self.expression: str = ""
 
     def accept(self, visitor: "BpmnVisitor") -> None:
-        visitor.visit_sequence_flow(self)
-        if not self.is_leaf:
+        if visitor.visit_sequence_flow(self):
             self.target_node.accept(visitor)
         visitor.end_visit_sequence_flow(self)
 
@@ -188,8 +202,7 @@ class MessageFlow(Flow):
         super().__init__(element)
 
     def accept(self, visitor: "BpmnVisitor") -> None:
-        visitor.visit_message_flow(self)
-        if not self.is_leaf:
+        if visitor.visit_message_flow(self):
             self.target_node.accept(visitor)
         visitor.end_visit_message_flow(self)
 
@@ -242,18 +255,6 @@ class Process(BpmnElement):
 # Bpmn class (building graph from xml happens here)
 ###################
 class Bpmn:
-    _TAG_CLASS_MAPPING: Dict[str, Type[BpmnElement]] = {
-        "task": Task,
-        "startEvent": StartEvent,
-        "endEvent": EndEvent,
-        "exclusiveGateway": ExclusiveGatewayNode,
-        "parallelGateway": ParallelGatewayNode,
-        "sendTask": IntermediateEvent,
-        "intermediateCatchEvent": IntermediateEvent,
-        "intermediateThrowEvent": IntermediateEvent,
-    }
-
-    _FLOW_MAPPING = {"sequenceFlow": SequenceFlow}
     _MSG_MAPPING = {"messageFlow": MessageFlow}
 
     def __init__(self) -> None:
@@ -269,23 +270,6 @@ class Bpmn:
 
     def add_inter_process_msg(self, msg: MessageFlow) -> None:
         self.inter_process_msgs[msg.id] = msg
-
-    def _set_leaf_flows(self) -> None:
-        visited = set()
-
-        def dfs(node: Node) -> None:
-            nonlocal visited
-
-            visited.add(node)
-            for flow in node.out_flows:
-                if flow.target_node in visited:
-                    flow.is_leaf = True
-                else:
-                    dfs(flow.target_node)
-
-        for process in self.processes.values():
-            for node in process.get_start_states().values():
-                dfs(node)
 
     def __str__(self) -> str:
         build_arr: List[str] = []
@@ -303,96 +287,6 @@ class Bpmn:
             build_arr.append("\n")
 
         return "\n".join(build_arr)
-
-    def _build_graph(self, process: Process) -> None:
-        for element_instance in process.all_items().values():
-            for outgoing in element_instance.element.findall(
-                "bpmn:outgoing", NAMESPACES
-            ):
-                flow_id = outgoing.text
-                if not flow_id:
-                    raise Exception("flow id is None")
-                flow = process[flow_id.strip()]
-                if not isinstance(flow, Flow):
-                    # TODO: Make a custom error here:
-                    raise Exception("flow not flow type")
-                if flow is not None:
-                    source_ref = self.get_element_from_id_mapping(
-                        flow.element.attrib["sourceRef"]
-                    )
-                    target_ref = self.get_element_from_id_mapping(
-                        flow.element.attrib["targetRef"]
-                    )
-
-                    if isinstance(source_ref, Node) and isinstance(target_ref, Node):
-                        # update flow's source_node
-                        flow.source_node = source_ref
-                        # update flow's target_node
-                        flow.target_node = target_ref
-
-                        if isinstance(flow, SequenceFlow):
-                            # update source node's out flows array
-                            source_ref.add_out_flow(flow)
-                            # update target node's in flows array
-                            target_ref.add_in_flow(flow)
-                    else:
-                        # TODO: Make a custom error here:
-                        raise TypeError("toNode or fromNode is not of type Node")
-
-    def _traverse_messages(self, root: Element) -> None:
-        self.collab = root.find("bpmn:collaboration", NAMESPACES)
-        if self.collab is not None:
-            for msg_flow in self.collab.findall("bpmn:messageFlow", NAMESPACES):
-                sourceRef, targetRef = (
-                    msg_flow.get("sourceRef"),
-                    msg_flow.get("targetRef"),
-                )
-
-                if not (sourceRef and targetRef):
-                    raise Exception(
-                        "source ref or target ref not included with message"
-                    )
-
-                message = MessageFlow(msg_flow)
-                self.add_inter_process_msg(message)
-                self.store_element(message)
-
-                fromNode, toNode = (
-                    self.get_element_from_id_mapping(sourceRef),
-                    self.get_element_from_id_mapping(targetRef),
-                )
-
-                if isinstance(fromNode, Node) and isinstance(toNode, Node):
-                    message.target_node, message.source_node = toNode, fromNode
-                    fromNode.add_out_msg(message)
-                    toNode.add_in_msg(message)
-                else:
-                    raise TypeError("toNode or fromNode is not of type Node")
-
-    def _traverse_process(self, process_element: Element) -> Process:
-        process = Process(process_element)
-
-        def get_tag_name(element: Element) -> str:
-            return element.tag.partition("}")[2]
-
-        for element in process_element:
-            tag_name = get_tag_name(element)
-            element_class = (
-                Bpmn._TAG_CLASS_MAPPING.get(tag_name)
-                or (
-                    Bpmn._TAG_CLASS_MAPPING["task"]
-                    if "task" in tag_name.lower()
-                    else None
-                )
-                or Bpmn._FLOW_MAPPING.get(tag_name)
-            )
-
-            if element_class:
-                element_instance = element_class(element)
-                process[element_instance.id] = element_instance
-                self.store_element(element_instance)
-
-        return process
 
     def accept(self, visitor: "BpmnVisitor") -> None:
         visitor.visit_bpmn(self)
@@ -420,20 +314,23 @@ class Bpmn:
         return str(promela_visitor)
 
     @staticmethod
-    def from_xml(xml_file: str) -> Result["Bpmn", Error]:
+    def from_xml(xml_file: str, symbol_table: SymbolTable) -> Result["Bpmn", Error]:
+        from bpmncwpverify.builder.bpmn_builder import BpmnBuilder
+
         try:
             tree = parse(xml_file)
             root = tree.getroot()
-            bpmn = Bpmn()
+            builder = BpmnBuilder()
             processes = root.findall("bpmn:process", NAMESPACES)
             for process_element in processes:
-                process = bpmn._traverse_process(process_element)
-                bpmn.processes[process.id] = process
-                bpmn._build_graph(process)
+                builder.add_process(process_element, symbol_table)
 
-            bpmn._traverse_messages(root)
-            bpmn._set_leaf_flows()
-            return Success(bpmn)
+            collab = root.find("bpmn:collaboration", NAMESPACES)
+            if collab is not None:
+                for msg_flow in collab.findall("bpmn:messageFlow", NAMESPACES):
+                    builder.add_message(msg_flow)
+
+            return builder.build()
         except Exception as e:
             return Failure(e)
 
@@ -484,26 +381,26 @@ class BpmnVisitor:
     def end_visit_parallel_gateway(self, gateway: ParallelGatewayNode) -> None:
         pass
 
-    def visit_sequence_flow(self, flow: SequenceFlow) -> None:
-        pass
+    def visit_sequence_flow(self, flow: SequenceFlow) -> bool:
+        return True
 
     def end_visit_sequence_flow(self, flow: SequenceFlow) -> None:
         pass
 
-    def visit_message_flow(self, flow: MessageFlow) -> None:
-        pass
+    def visit_message_flow(self, flow: MessageFlow) -> bool:
+        return True
 
     def end_visit_message_flow(self, flow: MessageFlow) -> None:
         pass
 
-    def visit_process(self, process: Process) -> None:
-        pass
+    def visit_process(self, process: Process) -> bool:
+        return True
 
     def end_visit_process(self, process: Process) -> None:
         pass
 
-    def visit_bpmn(self, bpmn: Bpmn) -> None:
-        pass
+    def visit_bpmn(self, bpmn: Bpmn) -> bool:
+        return True
 
     def end_visit_bpmn(self, bpmn: Bpmn) -> None:
         pass

--- a/src/bpmncwpverify/core/cwp.py
+++ b/src/bpmncwpverify/core/cwp.py
@@ -16,12 +16,12 @@ class Cwp:
 
     @staticmethod
     def from_xml(xml_file: str, symbol_table: SymbolTable) -> Result["Cwp", Error]:
-        from bpmncwpverify.builder.cwp_builder import ConcreteCwpBuilder
+        from bpmncwpverify.builder.cwp_builder import CwpBuilder
 
         try:
             tree = parse(xml_file)
             root = tree.getroot()
-            builder = ConcreteCwpBuilder(symbol_table)
+            builder = CwpBuilder(symbol_table)
 
             diagram = root.find("diagram")
             mx_graph_model = diagram.find("mxGraphModel")
@@ -124,20 +124,6 @@ class CwpEdge:
         if visitor.visit_edge(self):
             self.dest.accept(visitor)
         visitor.end_visit_edge(self)
-
-    def cleanup_expression(self, expression: str) -> str:
-        expression = re.sub(r"&amp;", "&", expression)
-        expression = re.sub(r"&lt;", "<", expression)
-        expression = re.sub(r"&gt;", ">", expression)
-
-        expression = re.sub(r"</?div>", "", expression)
-        expression = re.sub(r"<br>", " ", expression)
-
-        expression = re.sub(r"\s*(==|!=|&&|\|\|)\s*", r" \1 ", expression)
-
-        expression = re.sub(r"\s+", " ", expression)
-
-        return expression.strip()
 
 
 class CwpVisitor:

--- a/src/bpmncwpverify/core/expr.py
+++ b/src/bpmncwpverify/core/expr.py
@@ -146,7 +146,7 @@ class ExpressionListener(ExprListener):  # type: ignore
             return Failure(error)
 
     @staticmethod
-    def build(
+    def type_check(
         expression: str, symbol_table: SymbolTable
     ) -> Result["ExpressionListener", Error]:
         build_with_params = partial(ExpressionListener._build, symbol_table)

--- a/test/builder/test_cwp_builder.py
+++ b/test/builder/test_cwp_builder.py
@@ -1,4 +1,4 @@
-from bpmncwpverify.builder.cwp_builder import ConcreteCwpBuilder
+from bpmncwpverify.builder.cwp_builder import CwpBuilder
 from bpmncwpverify.core.cwp import CwpEdge, CwpState
 from returns.result import Success
 import pytest
@@ -9,7 +9,7 @@ from xml.etree.ElementTree import Element
 @pytest.fixture
 def builder(mocker):
     symbol_table = mocker.MagicMock()
-    return ConcreteCwpBuilder(symbol_table)
+    return CwpBuilder(symbol_table)
 
 
 def create_mock_state(mocker, state_id, out_edges=None, in_edges=None):
@@ -78,7 +78,6 @@ def test_add_and_check_expressions(mocker, builder):
     mock_expr_checker = mocker.MagicMock()
     mock_expr_checker.build.return_value = Success("bool")
     edge = create_mock_edge(mocker, "edge1")
-    edge.cleanup_expression.return_value = "someExpr"
     builder._cwp.edges = {"edge1": edge}
 
     all_items = [
@@ -94,8 +93,9 @@ def test_add_and_check_expressions(mocker, builder):
     ]
 
     builder._add_and_check_expressions(all_items, mock_expr_checker)
-    edge.cleanup_expression.assert_called_with("someExpr")
-    mock_expr_checker.build.assert_called_once_with("someExpr", builder.symbol_table)
+    mock_expr_checker.type_check.assert_called_once_with(
+        "someExpr", builder.symbol_table
+    )
     assert edge.parent_id == "expr1"
 
 
@@ -112,7 +112,7 @@ def test_build(mocker):
     mock_cwp = mocker.MagicMock()
     mock_cwp.states = states
 
-    obj = ConcreteCwpBuilder(mocker.MagicMock())
+    obj = CwpBuilder(mocker.MagicMock())
     obj._cwp = mock_cwp
     obj._cwp.states = states
     obj._cwp.edges = edges

--- a/test/core/test_expr.py
+++ b/test/core/test_expr.py
@@ -358,7 +358,7 @@ def test_given_good_state_when_build_then_success(state, expression, expression_
     assert is_successful(sym_table_result)
     symbol_table: SymbolTable = sym_table_result.unwrap()
 
-    expr_checker_result = ExpressionListener.build(expression, symbol_table)
+    expr_checker_result = ExpressionListener.type_check(expression, symbol_table)
 
     assert is_successful(expr_checker_result)
 
@@ -383,6 +383,6 @@ def test_given_bad_state_when_build_then_failure(state, expression):
     assert is_successful(sym_table_result)
     symbol_table: SymbolTable = sym_table_result.unwrap()
 
-    expr_checker_result = ExpressionListener.build(expression, symbol_table)
+    expr_checker_result = ExpressionListener.type_check(expression, symbol_table)
 
     assert not is_successful(expr_checker_result)

--- a/test/visitors/test_cwp_connectivity_visitor.py
+++ b/test/visitors/test_cwp_connectivity_visitor.py
@@ -1,10 +1,10 @@
 from xml.etree.ElementTree import Element
-from bpmncwpverify.builder.cwp_builder import ConcreteCwpBuilder
+from bpmncwpverify.builder.cwp_builder import CwpBuilder
 from bpmncwpverify.visitors.cwp_connectivity_visitor import CwpConnectivityVisitor
 
 
 def test_cwp_connectivity(mocker):
-    builder = ConcreteCwpBuilder(mocker.MagicMock())
+    builder = CwpBuilder(mocker.MagicMock())
     for i in range(10):
         builder.add_state(
             Element(f"state{i}", attrib={"id": f"state{i}", "style": "test"})


### PR DESCRIPTION
This PR (updating the cwp builder name, bpmn class and expression checker method) is one of several that together implement the builder that creates and ensures the correctness of a BPMN instance from an XML file. This PR is preparing the bpmn module to be able to work with the new builder interface. Here, I am removing a lot of the logic out of the bpmn module that will be placed in the bpmn builder in a future PR.

The major pieces staged in the coming PRs in order are:

1. Add new errors (already merged)
2. Update cwp builder name, prepare bpmn for bpmn builder interface and change `build` to `type_check` in expr.py (this PR)
3. Add process connectivity visitor
4. Add process builder (which uses process_connectivity_visitor)
5. Add bpmn connectivity visitor
6. Add bpmn builder (uses bpmn connectivity visitor)