### PR TITLE
Add Process_connectivity_visitor

### DIFF
--- a/src/bpmncwpverify/visitors/process_connectivity_visitor.py
+++ b/src/bpmncwpverify/visitors/process_connectivity_visitor.py
@@ -1,0 +1,104 @@
+from typing import Set
+from bpmncwpverify.core.bpmn import (
+    BpmnElement,
+    BpmnVisitor,
+    Flow,
+    GatewayNode,
+    Process,
+    SequenceFlow,
+    StartEvent,
+    EndEvent,
+    IntermediateEvent,
+    Task,
+    SubProcess,
+    ExclusiveGatewayNode,
+    ParallelGatewayNode,
+)
+from bpmncwpverify.error import BpmnStructureError
+
+
+class ProcessConnectivityVisitor(BpmnVisitor):  # type: ignore
+    def __init__(self) -> None:
+        self.visited: Set[BpmnElement] = set()
+        self.last_visited_set: Set[BpmnElement] = set()
+
+    def visit_start_event(self, event: StartEvent) -> bool:
+        self.visited.add(event)
+        return True
+
+    def visit_end_event(self, event: EndEvent) -> bool:
+        if event.out_flows:
+            raise Exception(
+                BpmnStructureError(
+                    event.id, "An end event cannot have outgoing sequence flow"
+                )
+            )
+        self.visited.add(event)
+        return True
+
+    def visit_intermediate_event(self, event: IntermediateEvent) -> bool:
+        self.visited.add(event)
+        return True
+
+    def visit_task(self, task: Task) -> bool:
+        self.visited.add(task)
+        return True
+
+    def visit_sub_process(self, subprocess: SubProcess) -> bool:
+        self.visited.add(subprocess)
+        return True
+
+    def _validate_out_flows(self, gateway: GatewayNode) -> None:
+        for out_flow in gateway.out_flows:
+            if not out_flow.expression:
+                raise Exception(
+                    BpmnStructureError(
+                        gateway.id,
+                        f"Flow: `{out_flow.id}` does not have an expression. All flows coming out of gateways must have expressions.",
+                    )
+                )
+
+    def visit_exclusive_gateway(self, gateway: ExclusiveGatewayNode) -> bool:
+        self._validate_out_flows(gateway)
+        self.visited.add(gateway)
+        return True
+
+    def visit_parallel_gateway(self, gateway: ParallelGatewayNode) -> bool:
+        self._validate_out_flows(gateway)
+        self.visited.add(gateway)
+        return True
+
+    def process_flow(self, flow: Flow) -> bool:
+        if flow.target_node in self.visited:
+            flow.is_leaf = True
+            return False
+        return True
+
+    def visit_sequence_flow(self, flow: SequenceFlow) -> bool:
+        return self.process_flow(flow)
+
+    def end_visit_process(self, process: Process) -> None:
+        # Ensure all items in the process graph are visited
+        if set(process.all_items().values()) != self.visited:
+            raise Exception("Process graph is not fully connected")
+
+        start_events = sum(
+            isinstance(itm, StartEvent) for itm in process.all_items().values()
+        )
+        end_events = sum(
+            isinstance(itm, EndEvent) for itm in process.all_items().values()
+        )
+
+        # Determine if there is a valid starting point
+        starting_point = start_events > 0 or any(
+            itm.in_msgs for itm in process.all_items().values()
+        )
+
+        if not starting_point or end_events == 0:
+            raise Exception(
+                f"Error with end events or start events: # end states = {end_events}, # start states = {start_events}"
+            )
+
+        # Testing and cleanup
+        self.last_visited_set = self.visited
+        self.visited = set()

--- a/test/visitors/test_process_connectivity_visitor.py
+++ b/test/visitors/test_process_connectivity_visitor.py
@@ -1,0 +1,231 @@
+# type: ignore
+from bpmncwpverify.error import BpmnStructureError
+import pytest
+from bpmncwpverify.core.bpmn import EndEvent, StartEvent
+from bpmncwpverify.visitors.process_connectivity_visitor import (
+    ProcessConnectivityVisitor,
+)
+
+
+@pytest.fixture
+def setup_process_and_visitor(mocker):
+    # Create a mock Process and visitor instance
+    process = mocker.MagicMock()
+    start_event = mocker.Mock(spec=StartEvent)
+    end_event = mocker.Mock(spec=EndEvent)
+    other_event = mocker.Mock()
+
+    visitor = ProcessConnectivityVisitor()
+
+    return process, visitor, start_event, end_event, other_event
+
+
+def test_fully_connected_graph(setup_process_and_visitor):
+    process, visitor, start_event, end_event, other_event = setup_process_and_visitor
+    # Simulate a fully connected graph
+    process.all_items.return_value = {
+        "start": start_event,
+        "middle": other_event,
+        "end": end_event,
+    }
+    visitor.visited = {start_event, other_event, end_event}
+
+    # No exception should be raised
+    visitor.end_visit_process(process)
+
+
+def test_disconnected_graph_raises_exception(setup_process_and_visitor):
+    process, visitor, start_event, end_event, other_event = setup_process_and_visitor
+    # Simulate a disconnected graph
+    process.all_items.return_value = {
+        "start": start_event,
+        "middle": other_event,
+        "end": end_event,
+    }
+    visitor.visited = {start_event, other_event}  # Missing end_event
+
+    with pytest.raises(Exception, match="Process graph is not fully connected"):
+        visitor.end_visit_process(process)
+
+
+def test_no_start_or_end_event_raises_exception(setup_process_and_visitor):
+    process, visitor, _, _, other_event = setup_process_and_visitor
+    # Simulate no StartEvent or EndEvent
+    process.all_items.return_value = {"middle": other_event}
+    visitor.visited = {other_event}
+    other_event.in_msgs = []
+
+    with pytest.raises(Exception, match="Error with end events or start events"):
+        visitor.end_visit_process(process)
+
+
+def test_no_start_event_with_incoming_msgs(setup_process_and_visitor):
+    process, visitor, _, end_event, other_event = setup_process_and_visitor
+    # Simulate no StartEvent but a valid starting point with incoming messages
+    process.all_items.return_value = {"middle": other_event, "end": end_event}
+    visitor.visited = {other_event, end_event}
+    other_event.in_msgs = [1]
+    end_event.in_msgs = []
+
+    # No exception should be raised
+    visitor.end_visit_process(process)
+
+
+def test_no_end_event_raises_exception(setup_process_and_visitor):
+    process, visitor, start_event, end_event, other_event = setup_process_and_visitor
+    # Simulate no EndEvent
+    process.all_items.return_value = {"start": start_event, "middle": other_event}
+    visitor.visited = {start_event, other_event}
+    start_event.in_msgs = []
+    other_event.in_msgs = [1]
+
+    with pytest.raises(Exception, match="Error with end events or start events"):
+        visitor.end_visit_process(process)
+
+
+def test_no_start_event_with_no_incoming_msgs(setup_process_and_visitor):
+    process, visitor, _, end_event, other_event = setup_process_and_visitor
+    # Simulate no StartEvent but a valid starting point with incoming messages
+    process.all_items.return_value = {"middle": other_event, "end": end_event}
+    visitor.visited = {other_event, end_event}
+    other_event.in_msgs = []
+    end_event.in_msgs = []
+
+    with pytest.raises(Exception, match="Error with end events or start events"):
+        visitor.end_visit_process(process)
+
+
+def test_valid_graph_resets_visited(setup_process_and_visitor):
+    process, visitor, start_event, end_event, _ = setup_process_and_visitor
+
+    process.all_items.return_value = {"start": start_event, "end": end_event}
+    visitor.visited = {start_event, end_event}
+    start_event.in_msgs = []
+    end_event.in_msgs = [1]
+
+    visitor.end_visit_process(process)
+
+    assert visitor.visited == set()
+
+
+def test_visit_end_event_no_outgoing_flows(mocker):
+    event = mocker.MagicMock()
+    event.out_flows = []
+    event.id = "end_event_1"
+
+    obj = ProcessConnectivityVisitor()
+    obj.visited = set()
+
+    result = obj.visit_end_event(event)
+
+    assert result is True
+    assert event in obj.visited
+
+
+def test_visit_end_event_with_outgoing_flows(mocker):
+    event = mocker.MagicMock()
+    event.out_flows = ["flow1"]
+    event.id = "end_event_2"
+
+    obj = ProcessConnectivityVisitor()
+    obj.visited = set()
+
+    with pytest.raises(Exception) as exc_info:
+        obj.visit_end_event(event)
+
+    assert isinstance(exc_info.value.args[0], BpmnStructureError)
+    assert "end_event_2" == str(exc_info.value.args[0].node_id)
+    assert "An end event cannot have outgoing sequence flow" == str(
+        exc_info.value.args[0].error_msg
+    )
+    assert event not in obj.visited
+
+
+def test_validate_out_flows_valid_case(mocker):
+    visitor = ProcessConnectivityVisitor()
+    gateway = mocker.MagicMock()
+    gateway.out_flows = [
+        mocker.MagicMock(expression=True),
+        mocker.MagicMock(expression=True),
+    ]
+    # Should not raise any exceptions
+    visitor._validate_out_flows(gateway)
+
+
+def test_validate_out_flows_invalid_case(mocker):
+    visitor = ProcessConnectivityVisitor()
+    gateway = mocker.MagicMock()
+    gateway.id = "gateway1"
+    gateway.out_flows = [
+        mocker.MagicMock(expression=True, id="flow1"),
+        mocker.MagicMock(expression=False, id="flow2"),
+    ]
+    with pytest.raises(Exception) as exc_info:
+        visitor._validate_out_flows(gateway)
+    assert isinstance(exc_info.value.args[0], BpmnStructureError)
+    assert (
+        "Flow: `flow2` does not have an expression. All flows coming out of gateways must have expressions."
+        == str(exc_info.value.args[0].error_msg)
+    )
+
+
+def test_visit_exclusive_gateway_valid(mocker):
+    visitor = ProcessConnectivityVisitor()
+    gateway = mocker.MagicMock()
+    gateway.out_flows = [
+        mocker.MagicMock(expression=True),
+        mocker.MagicMock(expression=True),
+    ]
+    mocker.patch.object(
+        visitor, "_validate_out_flows", wraps=visitor._validate_out_flows
+    )
+    result = visitor.visit_exclusive_gateway(gateway)
+    assert result is True
+    assert gateway in visitor.visited
+    visitor._validate_out_flows.assert_called_once_with(gateway)
+
+
+def test_visit_exclusive_gateway_invalid(mocker):
+    visitor = ProcessConnectivityVisitor()
+    gateway = mocker.MagicMock()
+    gateway.out_flows = [
+        mocker.MagicMock(expression=True),
+        mocker.MagicMock(expression=False),
+    ]
+    mocker.patch.object(
+        visitor, "_validate_out_flows", wraps=visitor._validate_out_flows
+    )
+    with pytest.raises(Exception):
+        visitor.visit_exclusive_gateway(gateway)
+    visitor._validate_out_flows.assert_called_once_with(gateway)
+
+
+def test_visit_parallel_gateway_valid(mocker):
+    visitor = ProcessConnectivityVisitor()
+    gateway = mocker.MagicMock()
+    gateway.out_flows = [
+        mocker.MagicMock(expression=True),
+        mocker.MagicMock(expression=True),
+    ]
+    mocker.patch.object(
+        visitor, "_validate_out_flows", wraps=visitor._validate_out_flows
+    )
+    result = visitor.visit_parallel_gateway(gateway)
+    assert result is True
+    assert gateway in visitor.visited
+    visitor._validate_out_flows.assert_called_once_with(gateway)
+
+
+def test_visit_parallel_gateway_invalid(mocker):
+    visitor = ProcessConnectivityVisitor()
+    gateway = mocker.MagicMock()
+    gateway.out_flows = [
+        mocker.MagicMock(expression=True),
+        mocker.MagicMock(expression=False),
+    ]
+    mocker.patch.object(
+        visitor, "_validate_out_flows", wraps=visitor._validate_out_flows
+    )
+    with pytest.raises(Exception):
+        visitor.visit_parallel_gateway(gateway)
+    visitor._validate_out_flows.assert_called_once_with(gateway)


### PR DESCRIPTION
This add the process connectivity visitor, which will be used in the process builder to check connectivity of processes, and other bpmn-related rules.