### PR TITLE
Add bpmn check 0101 to validate in flows

### DIFF
--- a/src/bpmncwpverify/error.py
+++ b/src/bpmncwpverify/error.py
@@ -85,6 +85,14 @@ class ExpressionUnrecognizedID(Error):
         return False
 
 
+class BpmnFlowIncomingError(Error):
+    __slots__ = ["node_id"]
+
+    def __init__(self, node_id: str) -> None:
+        super().__init__()
+        self.node_id = node_id
+
+
 class BpmnFlowNoIdError(Error):
     __slots__ = ["element"]
 
@@ -408,6 +416,8 @@ def _get_error_message(error: Error) -> str:
             return "ERROR: not implemented '{}'".format(function)
         case MessageError(node_id=node_id, error_msg=error_msg):
             return f"Inter-process message error at node: {node_id}. {error_msg}"
+        case BpmnFlowIncomingError(node_id=node_id):
+            return f"Flow error: No incoming flow into node: {node_id}."
         case BpmnFlowNoIdError(element=element):
             return f"Flow error: Flow_id does not exist. Occurred at tree element with following attributes: {element.attrib}."
         case BpmnFlowTypeError(flow_id=flow_id):

--- a/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidate.py
+++ b/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidate.py
@@ -1,6 +1,7 @@
 from bpmncwpverify.core.bpmn import Bpmn, Process
 from bpmncwpverify.error import BpmnMsgFlowSamePoolError
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidations import (
+    ValidateBpmnIncomingFlows,
     ValidateMsgsVisitor,
     ValidateSeqFlowVisitor,
     validate_start_end_events,
@@ -29,9 +30,11 @@ def validate_process(process: Process) -> None:
     process_connectivity_visitor = ProcessConnectivityVisitor()
     validate_msgs_visitor = ValidateMsgsVisitor()
     validate_seq_flow_visitor = ValidateSeqFlowVisitor()
+    validate_bpmn_incoming_flows = ValidateBpmnIncomingFlows()
 
     validate_start_end_events(process)
     process.accept(set_leafs_visitor)
     process.accept(process_connectivity_visitor)
     process.accept(validate_msgs_visitor)
     process.accept(validate_seq_flow_visitor)
+    process.accept(validate_bpmn_incoming_flows)

--- a/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidations.py
+++ b/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidations.py
@@ -14,6 +14,7 @@ from bpmncwpverify.core.bpmn import (
     ParallelGatewayNode,
 )
 from bpmncwpverify.error import (
+    BpmnFlowIncomingError,
     BpmnGraphConnError,
     BpmnMissingEventsError,
     BpmnMsgEndEventError,
@@ -127,6 +128,28 @@ class ValidateMsgsVisitor(BpmnVisitor):  # type: ignore
         self._ensure_in_messages(event, "intermediate event")
         self._ensure_out_messages(event, "intermediate event")
         return True
+
+
+class ValidateBpmnIncomingFlows(BpmnVisitor):  # type: ignore
+    def _check_in_flows(self, element: Node) -> bool:
+        if not element.in_flows:
+            raise Exception(BpmnFlowIncomingError(element.id))
+        return True
+
+    def visit_end_event(self, event: EndEvent) -> bool:
+        return self._check_in_flows(event)
+
+    def visit_intermediate_event(self, event: IntermediateEvent) -> bool:
+        return self._check_in_flows(event)
+
+    def visit_task(self, task: Task) -> bool:
+        return self._check_in_flows(task)
+
+    def visit_exclusive_gateway(self, gateway: ExclusiveGatewayNode) -> bool:
+        return self._check_in_flows(gateway)
+
+    def visit_parallel_gateway(self, gateway: ParallelGatewayNode) -> bool:
+        return self._check_in_flows(gateway)
 
 
 ##########################


### PR DESCRIPTION
BPMN 0101. All flow objects other than start events, boundary events, and compensating activities must have an incoming sequence flow, if the process level includes any start or end events.