### PR TITLE
Add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ cython_debug/
 # SPIN Artifacts
 pan
 *.trail
+
+.DS_Store


### PR DESCRIPTION
Add `.DS_Store` to the `.gitignore.`. Useful for Mac OSX users.]

Closes #69 