### PR TITLE
Refactor state to use the builder and error field

### DIFF
--- a/src/bpmncwpverify/cli.py
+++ b/src/bpmncwpverify/cli.py
@@ -137,7 +137,7 @@ class Builder:
     @staticmethod
     def _build_symbol_table(builder: "Builder") -> Result["Builder", Error]:
         assert is_successful(builder.state_str)
-        builder.symbol_table = State.build(builder.state_str.unwrap())
+        builder.symbol_table = State.from_str(builder.state_str.unwrap())
         if not_(is_successful)(builder.symbol_table):
             return Failure(builder.symbol_table.failure())
         else:

--- a/test/core/test_bpmn.py
+++ b/test/core/test_bpmn.py
@@ -2,7 +2,7 @@
 from xml.etree.ElementTree import Element, SubElement, tostring
 from defusedxml import ElementTree
 from bpmncwpverify.core.bpmn import Bpmn, BPMN_XML_NAMESPACE
-from bpmncwpverify.core.state import State
+from bpmncwpverify.core.state import StateBuilder
 from bpmncwpverify.core.error import BpmnMissingEventsError
 from returns.result import Failure, Success
 
@@ -44,7 +44,7 @@ def add_process_with_elements(root, elements):
 
 
 def test_complete_bpmn_with_no_start_or_end_event():
-    symbol_table = State()
+    symbol_table = StateBuilder().build()
     root = create_bpmn_definition()
     add_process(root)
     task = Element("bpmn:task", attrib={"id": "Task_1", "name": "Test Task"})
@@ -60,7 +60,7 @@ def test_complete_bpmn_with_no_start_or_end_event():
 
 
 def test_complete_bpmn_with_no_end_event():
-    symbol_table = State()
+    symbol_table = StateBuilder().build()
     root = create_bpmn_definition()
     add_process(root)
 
@@ -85,7 +85,7 @@ def test_complete_bpmn_with_no_end_event():
 
 
 def test_complete_bpmn_with_good_process():
-    symbol_table = State()
+    symbol_table = StateBuilder().build()
     root = create_bpmn_definition()
     add_process(root)
 

--- a/test/core/test_cwp.py
+++ b/test/core/test_cwp.py
@@ -26,7 +26,7 @@ def get_root_mx_root():
 
 
 def build_symbol_table(code):
-    symbol_table = State.build(code)
+    symbol_table = State.from_str(code)
     assert is_successful(symbol_table)
     return symbol_table.unwrap()
 

--- a/test/core/test_expr_interface.py
+++ b/test/core/test_expr_interface.py
@@ -42,7 +42,7 @@ import pytest
     ],
 )
 def test_given_good_state_when_build_then_success(state, expression, expression_type):
-    sym_table_result = State.build(state)
+    sym_table_result = State.from_str(state)
 
     assert is_successful(sym_table_result)
     symbol_table: State = sym_table_result.unwrap()
@@ -93,7 +93,7 @@ def test_given_good_state_when_build_then_success(state, expression, expression_
     ],
 )
 def test_given_bad_state_when_build_then_failure(state, expression, error):
-    sym_table_result = State.build(state)
+    sym_table_result = State.from_str(state)
 
     assert is_successful(sym_table_result)
     symbol_table: State = sym_table_result.unwrap()

--- a/test/core/test_state.py
+++ b/test/core/test_state.py
@@ -5,6 +5,7 @@ from antlr4.error.ErrorStrategy import ParseCancellationException
 from returns.pipeline import is_successful
 from returns.result import Result
 from returns.functions import not_
+from returns.maybe import Some
 
 from typing import Iterable
 
@@ -121,7 +122,7 @@ class Test_SymbolTable_build:
         # good_input
 
         # when
-        result = State.build(good_input)
+        result = State.from_str(good_input)
 
         # then
         assert is_successful(result)
@@ -131,7 +132,7 @@ class Test_SymbolTable_build:
         # bad_input
 
         # when
-        result = State.build(bad_input)
+        result = State.from_str(bad_input)
 
         # then
         assert not_(is_successful)(result)
@@ -163,7 +164,7 @@ class Test_SymbolTable_build:
         # good, expected
 
         # when
-        result = State.build(good_input)
+        result = State.from_str(good_input)
 
         # then
         assert is_successful(result)
@@ -179,19 +180,19 @@ class Test_SymbolTable_build:
             # Multiple Defnitionns
             (
                 "enum E {e e} var i : E = a {a}",
-                StateMultipleDefinitionError("e", 1, 10, 1, 8),
+                StateMultipleDefinitionError("e", Some(1), Some(10), Some(1), Some(8)),
             ),
             (
                 "enum E {e} enum E {f} var i : E = a {a}",
-                StateMultipleDefinitionError("E", 1, 16, 1, 5),
+                StateMultipleDefinitionError("E", Some(1), Some(16), Some(1), Some(5)),
             ),
             (
                 "enum E {e} const e : E = 0 var i : E = a {a}",
-                StateMultipleDefinitionError("e", 1, 17, 1, 8),
+                StateMultipleDefinitionError("e", Some(1), Some(17), Some(1), Some(8)),
             ),
             (
-                "const e : int = 0 var e : int = 0 {0, 1}",
-                StateMultipleDefinitionError("e", 1, 22, 1, 6),
+                "const e : int = 0 var e : int = 0 {0 1}",
+                StateMultipleDefinitionError("e", Some(1), Some(22), Some(1), Some(6)),
             ),
             # Bad const initializer
             (
@@ -220,7 +221,7 @@ class Test_SymbolTable_build:
                 TypingNoTypeError("a"),
             ),
             (
-                "enum E {e} var c : E = e {e, 0}",
+                "enum E {e} var c : E = e {e 0}",
                 TypingAssignCompatabilityError("E", typechecking.BIT),
             ),
             (
@@ -234,7 +235,7 @@ class Test_SymbolTable_build:
             # Var initial value not included in allowed values
             (
                 "enum E {e f} var c : E = e {f}",
-                StateInitNotInValues("e", 1, 25, {"f"}),
+                StateInitNotInValues("e", Some(1), Some(25), {"f"}),
             ),
         ],
     )
@@ -243,7 +244,7 @@ class Test_SymbolTable_build:
         # bad, expected
 
         # when
-        result = State.build(bad_input)
+        result = State.from_str(bad_input)
 
         # then
         assert not_(is_successful)(result)

--- a/test/test_error.py
+++ b/test/test_error.py
@@ -1,6 +1,8 @@
 # type: ignore
 import pytest
 
+from returns.maybe import Some, Nothing
+
 from bpmncwpverify.core.error import (
     Error,
     NotImplementedError,
@@ -15,12 +17,24 @@ from bpmncwpverify.core.error import (
 test_inputs: list[tuple[Error, str]] = [
     (NotImplementedError("notImplemented"), "ERROR: not implemented 'notImplemented'"),
     (
-        StateInitNotInValues("a", 0, 1, {"b", "c"}),
+        StateInitNotInValues("a", Some(0), Some(1), {"b", "c"}),
         "STATE ERROR: init value 'a' at line 0:1 not in allowed values ['b', 'c']",
     ),
     (
-        StateMultipleDefinitionError("a", 42, 43, 0, 1),
+        StateInitNotInValues("a", Nothing, Nothing, {"b", "c"}),
+        "STATE ERROR: init value 'a' not in allowed values ['b', 'c']",
+    ),
+    (
+        StateMultipleDefinitionError("a", Some(42), Some(43), Nothing, Nothing),
+        "STATE ERROR: multiple definition of 'a' at line 42:43",
+    ),
+    (
+        StateMultipleDefinitionError("a", Some(42), Some(43), Some(0), Some(1)),
         "STATE ERROR: multiple definition of 'a' at line 42:43, previously defined at line 0:1",
+    ),
+    (
+        StateMultipleDefinitionError("a", Nothing, Nothing, Nothing, Nothing),
+        "STATE ERROR: multiple definition of 'a'",
     ),
     (StateSyntaxError("bad syntax"), "STATE SYNTAX ERROR: bad syntax"),
     (
@@ -31,7 +45,10 @@ test_inputs: list[tuple[Error, str]] = [
 ]
 test_ids: list[str] = [
     "NotImplementedError",
+    "StateInitNotInValuesLineCol",
     "StateInitNotInValues",
+    "StateMultipleDefinitionErrorLineCol",
+    "StateMultipleDefinitionErrorLineColPrevLinePrevCol",
     "StateMultipleDefinitionError",
     "StateSyntaxError",
     "TypeingAssignCompatabilityError",


### PR DESCRIPTION
Refactor to use a builder in conjunction with the listener to build an instance of a `State` (formerly `SymbolTable`).  The refactor touches a whole bunch of files since the `State` is used in several tests and the `cwp_ltl_visitor.py` file. That file will be refactored to use a public interface in the next PR.

@tklaback,  the visitor adds specific elements to the builder, and when the listener finishes the traversal, it calls the `state_builder.build()` to create an instance of the `State` object. All of the error detection is in the `State` class and is triggered in the build.

@jminyoon, the exception no longer carries the error; rather, I have a `Maybe[Error]` attribute in the listener so that when the exception fires, the error is taken from the listener rather than the exception.

Close #79
Fix #63