### PR TITLE
Add line of promela code for inlining behavior

### DIFF
--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -189,6 +189,12 @@ class PromelaGenVisitor(BpmnVisitor):  # type: ignore
         self.behaviors.write_str("skip", NL_SINGLE)
         self.behaviors.write_str("}", NL_DOUBLE, IndentAction.DEC)
 
+    def _execute_methods(self, event: Node) -> None:
+        self._gen_behavior_model(event)
+        atomic_block = self._build_atomic_block(event)
+
+        self.promela.write_str(atomic_block)
+
     def __repr__(self) -> str:
         return f"{self.defs}{self.behaviors}{self.init_proc_contents}{self.promela}"
 
@@ -196,51 +202,34 @@ class PromelaGenVisitor(BpmnVisitor):  # type: ignore
     # Visitor Methods
     ####################
     def visit_start_event(self, event: StartEvent) -> bool:
-        self._gen_behavior_model(event)
         self.promela.write_str(f"putToken({event.name})", NL_SINGLE, IndentAction.NIL)
         self.promela.write_str("do", NL_SINGLE, IndentAction.NIL)
 
-        atomic_block = self._build_atomic_block(event)
+        self._execute_methods(event)
 
-        self.promela.write_str(atomic_block)
         return True
 
     def visit_end_event(self, event: EndEvent) -> bool:
-        self._gen_behavior_model(event)
-        atomic_block = self._build_atomic_block(event)
-
-        self.promela.write_str(atomic_block)
+        self._execute_methods(event)
         return True
 
     def visit_intermediate_event(self, event: IntermediateEvent) -> bool:
-        self._gen_behavior_model(event)
-        atomic_block = self._build_atomic_block(event)
-
-        self.promela.write_str(atomic_block)
+        self._execute_methods(event)
         return True
 
     def visit_task(self, task: Task) -> bool:
-        self._gen_behavior_model(task)
-        atomic_block = self._build_atomic_block(task)
-
-        self.promela.write_str(atomic_block)
+        self._execute_methods(task)
         return True
 
     def visit_exclusive_gateway(self, gateway: ExclusiveGatewayNode) -> bool:
-        self._gen_behavior_model(gateway)
-        atomic_block = self._build_atomic_block(gateway)
-
-        self.promela.write_str(atomic_block)
+        self._execute_methods(gateway)
         return True
 
     def end_visit_exclusive_gateway(self, gateway: ExclusiveGatewayNode) -> None:
         pass
 
     def visit_parallel_gateway(self, gateway: ParallelGatewayNode) -> bool:
-        self._gen_behavior_model(gateway)
-        atomic_block = self._build_atomic_block(gateway)
-
-        self.promela.write_str(atomic_block)
+        self._execute_methods(gateway)
         return True
 
     def visit_message_flow(self, flow: MessageFlow) -> bool:

--- a/test/visitors/test_bpmn_promela_visitor.py
+++ b/test/visitors/test_bpmn_promela_visitor.py
@@ -278,5 +278,15 @@ def test_build_atomic_block(promela_visitor, mocker):
 
     atomic_block = promela_visitor._build_atomic_block(node1)
 
-    expected_output = ":: atomic { (hasToken(NODE1_FROM_NODE2)||hasToken(NODE1_FROM_NODE3)) ->\n\td_step {\n\t\tconsumeToken(NODE1_FROM_NODE2)\n\t\tconsumeToken(NODE1_FROM_NODE3)\n\t\tputToken(NODE4_FROM_NODE1)\n\t}\n}\n"
+    expected_output = ":: atomic { (hasToken(NODE1_FROM_NODE2)||hasToken(NODE1_FROM_NODE3)) ->\n\tNODE1_BehaviorModel()\n\td_step {\n\t\tconsumeToken(NODE1_FROM_NODE2)\n\t\tconsumeToken(NODE1_FROM_NODE3)\n\t\tputToken(NODE4_FROM_NODE1)\n\t}\n}\n"
     assert str(atomic_block) == expected_output
+
+
+def test_gen_behavior_model(promela_visitor, mocker):
+    node1 = mocker.Mock()
+    node1.name = "TEST"
+
+    promela_visitor._gen_behavior_model(node1)
+    assert (
+        str(promela_visitor.behaviors) == "inline TEST_BehaviorModel(){\n\tskip\n}\n\n"
+    )


### PR DESCRIPTION
This is among the promela generation PRs meant to build a behavior model for each element in the bpmn, then inline that behavior model in its respective atomic block in the `do` loop.

Fix #115 