### PR TITLE
Bpmn init fix

### DIFF
--- a/src/bpmncwpverify/builder/process_builder.py
+++ b/src/bpmncwpverify/builder/process_builder.py
@@ -1,26 +1,21 @@
-from typing import Union, cast
-from xml.etree.ElementTree import Element
-from bpmncwpverify.core.bpmn import (
-    Node,
-    Process,
-    SequenceFlow,
-)
-from bpmncwpverify.core.error import (
-    BpmnStructureError,
-)
+from bpmncwpverify.core.bpmn import Node, Process, SequenceFlow
 from bpmncwpverify.core.expr import ExpressionListener
+from bpmncwpverify.core.error import BpmnStructureError
 from bpmncwpverify.core.state import State
+from bpmncwpverify.visitors.bpmnchecks.bpmnvalidate import validate_process
+
 from returns.result import Result
 from returns.pipeline import is_successful
 from returns.functions import not_
-from bpmncwpverify.visitors.bpmnchecks.bpmnvalidate import validate_process
+
+from typing import Union, cast
 
 
 class ProcessBuilder:
     __slots__ = ["_process", "_symbol_table"]
 
-    def __init__(self, element: Element, symbol_table: State) -> None:
-        self._process = Process(element)
+    def __init__(self, id: str, name: str, symbol_table: State) -> None:
+        self._process = Process(id, name)
         self._symbol_table = symbol_table
 
     def with_element(self, element: Union[SequenceFlow, Node]) -> "ProcessBuilder":

--- a/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
@@ -17,6 +17,7 @@ from returns.result import Result
 from typing import cast
 from xml.etree.ElementTree import Element
 
+
 def generate_promela(bpmn: Bpmn) -> str:
     promela_visitor = PromelaGenVisitor()
 

--- a/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
@@ -1,22 +1,21 @@
-from typing import cast
-from xml.etree.ElementTree import Element
-from bpmncwpverify.core.state import State
-from returns.result import Result
-from returns.pipeline import is_successful
-from returns.functions import not_
-from bpmncwpverify.core.error import (
-    Error,
-)
+from bpmncwpverify.builder.bpmn_builder import BpmnBuilder
+from bpmncwpverify.core.accessmethods.processmethods import from_xml as process_from_xml
 from bpmncwpverify.core.bpmn import (
     Bpmn,
     BPMN_XML_NAMESPACE,
     MessageFlow,
 )
-from bpmncwpverify.builder.bpmn_builder import BpmnBuilder
-from bpmncwpverify.core.accessmethods.processmethods import from_xml as process_from_xml
+from bpmncwpverify.core.error import Error
+from bpmncwpverify.core.state import State
 from bpmncwpverify.visitors.bpmn_promela_visitor import PromelaGenVisitor
 from bpmncwpverify.visitors.bpmn_graph_visitor import GraphVizVisitor
 
+from returns.functions import not_
+from returns.pipeline import is_successful
+from returns.result import Result
+
+from typing import cast
+from xml.etree.ElementTree import Element
 
 def generate_promela(bpmn: Bpmn) -> str:
     promela_visitor = PromelaGenVisitor()

--- a/src/bpmncwpverify/core/accessmethods/processmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/processmethods.py
@@ -2,10 +2,7 @@ from typing import cast
 from xml.etree.ElementTree import Element
 from bpmncwpverify.core.state import State
 from returns.result import Result
-from bpmncwpverify.core.error import (
-    Error,
-)
-
+from bpmncwpverify.core.error import Error
 from bpmncwpverify.builder.process_builder import ProcessBuilder
 from bpmncwpverify.core.bpmn import Process, get_element_type, BPMN_XML_NAMESPACE
 

--- a/src/bpmncwpverify/core/accessmethods/processmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/processmethods.py
@@ -7,11 +7,12 @@ from bpmncwpverify.builder.process_builder import ProcessBuilder
 from bpmncwpverify.core.bpmn import Process, get_element_type, BPMN_XML_NAMESPACE
 
 
-def from_xml(
-    element: Element,
-    symbol_table: State,
-) -> Result["Process", Error]:
-    builder = ProcessBuilder(element, symbol_table)
+def from_xml(element: Element, symbol_table: State) -> Result["Process", Error]:
+    id = element.attrib.get("id")
+    if not id:
+        raise Exception("Id cannot be None")
+    name: str = element.attrib.get("name", id)
+    builder = ProcessBuilder(id, name, symbol_table)
 
     for sub_element in element:
         tag = sub_element.tag.partition("}")[2]

--- a/src/bpmncwpverify/core/bpmn.py
+++ b/src/bpmncwpverify/core/bpmn.py
@@ -52,10 +52,16 @@ class Node(BpmnElement):
         "message_timer_definition",
     ]
 
-    def __init__(self, id: str, name: str, message_event_definition: str, message_timer_definition: str) -> None:
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        message_event_definition: str,
+        message_timer_definition: str,
+    ) -> None:
         """
         Initialize Node object
-        
+
         Args:
             message_event_definition (str): Definition of message event if available
             message_timer_definition (str): Definition of message timer if available
@@ -124,23 +130,24 @@ class Node(BpmnElement):
             visitor (BpmnVisitor): Visitor that will traverse through BPMN elements
         """
         pass
-    
+
     @classmethod
     def from_xml(cls: Type[T], element):
         instance = super().from_xml(element)
-        message_event = element.find(
-            "bpmn:messageEventDefinition", BPMN_XML_NAMESPACE
-        )
+        message_event = element.find("bpmn:messageEventDefinition", BPMN_XML_NAMESPACE)
         message_event_definition: str = (
-            message_event.attrib.get("id", "")
-            if message_event is not None
-            else ""
+            message_event.attrib.get("id", "") if message_event is not None else ""
         )
         timer_event = element.find("bpmn:timerEventDefinition", BPMN_XML_NAMESPACE)
         message_timer_definition: str = (
             timer_event.attrib.get("id", "") if timer_event is not None else ""
         )
-        return cls(instance.id, instance.name, message_event_definition, message_timer_definition)
+        return cls(
+            instance.id,
+            instance.name,
+            message_event_definition,
+            message_timer_definition,
+        )
 
 
 # Event classes
@@ -179,10 +186,17 @@ class IntermediateEvent(Event):
     Events between start and end events
     """
 
-    def __init__(self, id: str, name: str, message_event_definition: str, message_timer_definition: str, type: str):
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        message_event_definition: str,
+        message_timer_definition: str,
+        type: str,
+    ):
         """
         Initialize IntermediateEvent object
-        
+
         Args:
             type (str): Type of IntermediateEvent
         """
@@ -193,13 +207,19 @@ class IntermediateEvent(Event):
         result = visitor.visit_intermediate_event(self)
         self.traverse_outflows_if_result(visitor, result)
         visitor.end_visit_intermediate_event(self)
-        
+
     @classmethod
     def from_xml(cls: Type[T], element):
         instance = super().from_xml(element)
         tag = element.tag.partition("}")[2]
         type = "catch" if "Catch" in tag else "throw" if "Throw" in tag else "send"
-        return cls(instance.id, instance.name, instance.message_event_definition, instance.message_timer_definition, type)
+        return cls(
+            instance.id,
+            instance.name,
+            instance.message_event_definition,
+            instance.message_timer_definition,
+            type,
+        )
 
 
 # Activity classes
@@ -239,7 +259,14 @@ class ParallelGatewayNode(GatewayNode):
     Gateway that allows multiple paths to be taken
     """
 
-    def __init__(self, id: str, name: str, message_event_definition: str, message_timer_definition: str, is_fork: bool = False):
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        message_event_definition: str,
+        message_timer_definition: str,
+        is_fork: bool = False,
+    ):
         """
         Initialize ParallelGatewayNode object
 
@@ -258,11 +285,17 @@ class ParallelGatewayNode(GatewayNode):
         super().add_out_flow(flow)
         if len(self.out_flows) > 1:
             self.is_fork = True
-    
+
     @classmethod
     def from_xml(cls: Type[T], element, is_fork: bool = False):
         instance = super().from_xml(element)
-        return cls(instance.id, instance.name, instance.message_event_definition, instance.message_timer_definition, is_fork)
+        return cls(
+            instance.id,
+            instance.name,
+            instance.message_event_definition,
+            instance.message_timer_definition,
+            is_fork,
+        )
 
 
 # Flow classes

--- a/test/builder/test_process_builder.py
+++ b/test/builder/test_process_builder.py
@@ -9,7 +9,7 @@ def test_add_element(mocker):
     mock_element = mocker.MagicMock()
     mock_element.id = "1"
 
-    builder = ProcessBuilder(mocker.MagicMock(), mocker.MagicMock())
+    builder = ProcessBuilder(mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock())
 
     mock_process = mocker.MagicMock()
     builder._process = mock_process
@@ -56,7 +56,7 @@ def test_build_graph(mocker):
 
     mock_process.element.findall.return_value = [element_1, element_2]
 
-    builder = ProcessBuilder(mocker.Mock(), mocker.Mock())
+    builder = ProcessBuilder(mocker.Mock(), mocker.Mock(), mocker.Mock())
     builder._process = mock_process
 
     builder.with_process_flow("flow_1", "node_1", "node_2", None)
@@ -94,7 +94,7 @@ def test_build_graph_with_expression_checker(mocker):
         return_value=Success("bool"),
     )
 
-    builder = ProcessBuilder(mocker.Mock(), mock_symbol_table)
+    builder = ProcessBuilder(mocker.Mock(), mocker.Mock, mock_symbol_table)
     builder._process = mock_process
 
     builder.with_process_flow("flow_1", "node_1", "node_2", "clean_expression")


### PR DESCRIPTION
@ericmercer 
Line 351 `__init__` method for `Process` is breaking because arguments changed from `element` to `id, name`, `element` being a `Element` from `xml.etree.ElementTree` and `id, name` both being `str`. Can be seen in use in `process_builder.py`, line 23