### PR TITLE
Add base Spin output method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ pan
 *.trail
 
 .DS_Store
+
+# vs-code workspaces
+work.code-workspace

--- a/src/bpmncwpverify/core/spin.py
+++ b/src/bpmncwpverify/core/spin.py
@@ -1,0 +1,17 @@
+from returns.result import Result, Success
+from bpmncwpverify.core.error import Error
+import subprocess
+
+
+class Coverage:
+    pass
+
+
+class SpinOutput:
+    @staticmethod
+    def get_spin_output(file_path: str) -> Result[Coverage, Error]:
+        subprocess.run(
+            ["spin", "-run", "-noclaim", file_path], capture_output=True, text=True
+        ).stdout
+
+        return Success(Coverage())

--- a/test/resources/simple_example/valid_output.pml
+++ b/test/resources/simple_example/valid_output.pml
@@ -1,3 +1,6 @@
+
+int x = 0
+
 #define Gateway_1_hasOption \
 (\
     x > 5||\
@@ -47,10 +50,7 @@ inline Gateway_1_BehaviorModel() {
 
 
 init {
-    atomic{
-        updateState()
-        run Process_1()
-    }
+    run Process_1()
 }
 
 
@@ -100,6 +100,7 @@ do
             if
                 :: x > 5 -> putToken(End_FROM_Gateway_1)
                 :: x <=5 -> putToken(Increment_x_FROM_Gateway_1)
+                :: else -> assert false
             fi
         }
     }
@@ -109,6 +110,7 @@ do
         d_step {
             consumeToken(End_FROM_Gateway_1)
         }
+        break
     }
 od
 }


### PR DESCRIPTION
This is the first PR of several that aim to display to the user spin's output from the generated promela. This PR just adds a subroutine, which starts a subprocess that runs the spin verification.