### PR TITLE
Remove printf statement from bpmn_promela_visitor

### DIFF
--- a/src/bpmncwpverify/builder/filebuilder.py
+++ b/src/bpmncwpverify/builder/filebuilder.py
@@ -94,7 +94,8 @@ class StateBuilder:
         variableNames = self.variable_name_extractor(state)
         loggerFunction = StringManager()
 
-        loggerFunction.write_str("inline stateLogger(){", NL_SINGLE, IndentAction.INC)
+        loggerFunction.write_str("inline stateLogger(id){", NL_SINGLE, IndentAction.INC)
+        loggerFunction.write_str('printf("ID: %e\\n", id)', NL_SINGLE)
         loggerFunction.write_str('printf("Changed Vars: \\n");', NL_SINGLE)
         for varName in variableNames:
             loggerFunction.write_str("if", NL_SINGLE, IndentAction.INC)

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -338,8 +338,7 @@ class PromelaGenVisitor(BpmnVisitor):  # type: ignore
     # Visitor Methods
     ####################
     def print_element_id(self, element: BpmnElement) -> None:
-        self.promela.write_str(f'printf("ID: {element.id}\\n")', NL_SINGLE)
-        self.promela.write_str("stateLogger()", NL_SINGLE)
+        self.promela.write_str(f"stateLogger({element.name})", NL_SINGLE)
 
     def visit_start_event(self, event: StartEvent) -> bool:
         self.print_element_id(event)

--- a/test/builder/test_filebuilder.py
+++ b/test/builder/test_filebuilder.py
@@ -22,7 +22,8 @@ def test_logger_generator(mocker):
     sb.logger_generator(state, cwp)
 
     calls = [
-        mocker.call("inline stateLogger(){", NL_SINGLE, IndentAction.INC),
+        mocker.call("inline stateLogger(id){", NL_SINGLE, IndentAction.INC),
+        mocker.call('printf("ID: %e\\n", id)', NL_SINGLE),
         mocker.call('printf("Changed Vars: \\n");', NL_SINGLE),
         mocker.call("if", NL_SINGLE, IndentAction.INC),
         mocker.call(

--- a/test/visitors/test_bpmn_promela_visitor.py
+++ b/test/visitors/test_bpmn_promela_visitor.py
@@ -584,7 +584,7 @@ def test_print_element_id(promela_visitor, mocker):
     sm = mocker.patch(
         "bpmncwpverify.visitors.bpmn_promela_visitor.StringManager.write_str"
     )
-    mock_element = mocker.Mock(id="test_id")
+    mock_element = mocker.Mock(id="test_id", name="test_name")
 
     promela_visitor.print_element_id(mock_element)
-    sm.assert_has_calls([call('printf("ID: test_id\\n")', 1), call("stateLogger()", 1)])
+    sm.assert_has_calls([call(f"stateLogger({mock_element.name})", 1)])


### PR DESCRIPTION
Design `stateLogger` to accept a string that represents the `id` then prints the name of the variable which is the `id`

Close #245