### PR TITLE
Fix coverage reporting and error detection

### DIFF
--- a/src/bpmncwpverify/core/spin.py
+++ b/src/bpmncwpverify/core/spin.py
@@ -91,7 +91,7 @@ class SpinOutput:
 
         # Regular expression to match line information
         line_pattern = re.compile(
-            r"(?P<file>[\w\.]+):(?P<line>\d+), state \d+, (?P<message>\".*?\")"
+            r"(?P<file>[\w\.]+):(?P<line>\d+), state \d+, (?P<message>\"(?!.*assert).*?\")"
         )
 
         # Find all relevant blocks (excluding never claims)

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -339,11 +339,13 @@ class PromelaGenVisitor(BpmnVisitor):  # type: ignore
 
         atomic_block.write_str(guard)
         atomic_block.write_str(") ->", NL_SINGLE, IndentAction.INC)
-        atomic_block.write_str(f'printf("ID: {ctx.element.id}\\n")', NL_SINGLE)
         if ctx.behavior_model:
             atomic_block.write_str(f"{ctx.element.id}_BehaviorModel()", NL_SINGLE)
-            atomic_block.write_str("stateLogger()", NL_SINGLE)
+
         atomic_block.write_str("d_step {", NL_SINGLE, IndentAction.INC)
+
+        atomic_block.write_str(f'printf("ID: {ctx.element.id}\\n")', NL_SINGLE)
+        atomic_block.write_str("stateLogger()", NL_SINGLE)
 
         for location in self._get_consume_locations(ctx.element).get_all_positions():
             atomic_block.write_str(f"consumeToken({location})", NL_SINGLE)
@@ -410,6 +412,8 @@ class PromelaGenVisitor(BpmnVisitor):  # type: ignore
 
         for loc in self._get_consume_locations(event).get_all_positions():
             self.promela.write_str(f"putToken({loc})", NL_SINGLE, IndentAction.NIL)
+        # Close the d_step from the `visit_process`
+        self.promela.write_str("}", NL_SINGLE, IndentAction.DEC)
 
         self.promela.write_str("do", NL_SINGLE, IndentAction.NIL)
 
@@ -485,6 +489,7 @@ class PromelaGenVisitor(BpmnVisitor):  # type: ignore
         self.promela.write_str(
             f"proctype {process.id}() {{", NL_SINGLE, IndentAction.INC
         )
+        self.promela.write_str("d_step {", NL_SINGLE, IndentAction.INC)
         self.promela.write_str(f'printf("ID: {process.id}\\n")', NL_SINGLE)
         self.promela.write_str("stateLogger()", NL_SINGLE)
         self.promela.write_str("pid me = _pid", NL_SINGLE, IndentAction.NIL)

--- a/test/visitors/test_bpmn_promela_visitor.py
+++ b/test/visitors/test_bpmn_promela_visitor.py
@@ -358,7 +358,7 @@ def test_build_atomic_block(promela_visitor, mocker):
 
     atomic_block = promela_visitor._build_atomic_block(ctx)
 
-    expected_output = ':: atomic { ((hasToken(NODE1_FROM_NODE2) || hasToken(NODE1_FROM_NODE3))) ->\n\tprintf("ID: NODE1\\n")\n\tNODE1_BehaviorModel()\n\tstateLogger()\n\td_step {\n\t\tconsumeToken(NODE1_FROM_NODE2)\n\t\tconsumeToken(NODE1_FROM_NODE3)\n\t\tputToken(NODE4_FROM_NODE1)\n\t}\n}\n'
+    expected_output = ':: atomic { ((hasToken(NODE1_FROM_NODE2) || hasToken(NODE1_FROM_NODE3))) ->\n\tNODE1_BehaviorModel()\n\td_step {\n\t\tprintf("ID: NODE1\\n")\n\t\tstateLogger()\n\t\tconsumeToken(NODE1_FROM_NODE2)\n\t\tconsumeToken(NODE1_FROM_NODE3)\n\t\tputToken(NODE4_FROM_NODE1)\n\t}\n}\n'
     assert str(atomic_block) == expected_output
 
 
@@ -582,6 +582,7 @@ def test_visit_start_state(promela_visitor, mocker):
 
     calls = [
         mocker.call("putToken(test_loc)", NL_SINGLE, IndentAction.NIL),
+        mocker.call("}", NL_SINGLE, IndentAction.DEC),
         mocker.call("do", NL_SINGLE, IndentAction.NIL),
         mocker.call("atomic_block"),
     ]


### PR DESCRIPTION
Close #259 — face2face should not error
Close #260 — coverage report excludes `assert`