### PR TITLE
Rename to promela_builder and type fix all files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,12 +35,11 @@
                 "mypy.configFile": "${workspaceFolder}/pyproject.toml",
                 "mypy.path": "/home/vscode/.local/bin/mypy",
                 "python.analysis.extraPaths": [
+                    "${workspaceFolder}/src",
                     "/home/vscode/.local/lib/python3.12/site-packages"
                 ],
-                "python.analysis.typeCheckingMode": "strict",
-                "python.analysis.diagnosticSeverityOverrides": {
-                    "reportUnknownArgumentType": "none"
-                }
+                "python.languageServer": "Pylance",
+                "python.analysis.diagnosticMode": "workspace"
             },
             "extensions": ["mike-lischke.vscode-antlr4", "ms-python.mypy-type-checker", "charliermarsh.ruff", "peacekeeper228.spin-promela"]
         }

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -32,6 +32,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --editable ".[dev]"
+        python -c "import returns.contrib.mypy.returns_plugin"
     - name: Pre-commit
       uses: pre-commit/action@v3.0.1
     - name: Test pass-off

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,13 +36,6 @@ repos:
         additional_dependencies: []
         exclude: ^src/bpmncwpverify/antlr
         minimum_pre_commit_version: "2.9.2"
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.13.0'  # Use the sha / tag you want to point at
-    hooks:
-    -   id: mypy
-        additional_dependencies: ['returns']
-        args: ["--config-file=pyproject.toml"]
-        exclude: ^(test/|src/bpmncwpverify/antlr/|original/)
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
@@ -50,10 +43,19 @@ repos:
         exclude: ^src/bpmncwpverify/antlr
     -   id: remove-tabs
         exclude: ^src/bpmncwpverify/antlr
-- repo: local
-  hooks:
-    - id: pyright-type-check
-      name: Pyright Type Check
-      entry: pyright
-      language: system
-      types: [python]
+-   repo: local
+    hooks:
+      - id: mypy
+        name: mypy (with returns plugin)
+        entry: python -m mypy
+        language: system
+        types: [python]
+        args: ["--config-file=pyproject.toml"]
+        exclude: ^(test/|src/bpmncwpverify/antlr/|original/)
+-   repo: local
+    hooks:
+    -   id: pyright
+        name: Pyright Type Check
+        entry: pyright
+        language: system
+        types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
   "nitpick",
   "antlr4-tools",
   "pytest-cov",
+  "types-requests",
   ]
 
 [tool.ruff]
@@ -59,10 +60,3 @@ disallow_subclassing_any = true
 
 [tool.pytest.ini_options]
 addopts = "--cov=./src/bpmncwpverify/ --cov-report=html --cov-report=term"
-
-[tool.pyright]
-include = ["src"]
-exclude = [
-    "original",
-    "src/bpmncwpverify/antlr"
-]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,20 @@
+{
+  "typeCheckingMode": "strict",
+  "pythonVersion": "3.12",
+  "include": ["src"],
+  "exclude": [
+    "original",
+    "src/bpmncwpverify/antlr",
+    "test",
+    "**/__pycache__",
+    "**/.venv",
+    "**/.mypy_cache",
+    "**/build",
+    "**/dist"
+  ],
+  "reportUnknownArgumentType": false,
+  "extraPaths": [
+    "src",
+    "/home/vscode/.local/lib/python3.12/site-packages",
+  ]
+}

--- a/src/bpmncwpverify/builder/process_builder.py
+++ b/src/bpmncwpverify/builder/process_builder.py
@@ -1,6 +1,5 @@
 from bpmncwpverify.core.bpmn import Node, Process, SequenceFlow, Task
 from bpmncwpverify.core.expr import ExpressionListener
-from bpmncwpverify.core.error import BpmnStructureError
 from bpmncwpverify.core.state import State
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidate import validate_process
 from bpmncwpverify.core.error import Error, FlowExpressionError, get_error_message
@@ -9,7 +8,7 @@ from returns.result import Result, Failure, Success
 from returns.pipeline import is_successful
 from returns.functions import not_
 
-from typing import Union, cast
+from typing import Union
 
 
 class ProcessBuilder:
@@ -38,8 +37,7 @@ class ProcessBuilder:
                     parent_task, Task
                 ), f"Boundary event '{bpmn_object.id}' is attached to non-Task object: {type(parent_task).__name__}"
 
-                task = cast(Task, parent_task)
-                task.add_boundary_event(bpmn_object)
+                parent_task.add_boundary_event(bpmn_object)
 
         return self
 
@@ -78,5 +76,5 @@ class ProcessBuilder:
         target_node.add_in_flow(flow)
         return Success(self)
 
-    def build(self) -> Result[Process, BpmnStructureError]:
-        return cast(Result, validate_process(self._process))
+    def build(self) -> Result[Process, Error]:
+        return validate_process(self._process)

--- a/src/bpmncwpverify/client_cli/clientcli.py
+++ b/src/bpmncwpverify/client_cli/clientcli.py
@@ -6,7 +6,7 @@ from returns.io import impure_safe, IOResultE
 from returns.pipeline import managed, flow
 from returns.result import ResultE, Result, Success, Failure
 from typing import TextIO
-import requests  # type: ignore
+import requests
 from returns.unsafe import unsafe_perform_io
 
 LAMBDA_URL = "https://cxvqggpd6swymxnmahwvgfsina0tiokb.lambda-url.us-east-1.on.aws/"

--- a/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
@@ -57,7 +57,7 @@ def from_xml(root: Element, state: State) -> Result["Bpmn", Error]:
 
             bpmn_builder = bpmn_builder.with_message(message, source_ref, target_ref)
 
-    return cast(Result[Bpmn, Error], bpmn_builder.build())
+    return bpmn_builder.build()
 
 
 def generate_graph_viz(bpmn: Bpmn) -> None:

--- a/src/bpmncwpverify/core/bpmn.py
+++ b/src/bpmncwpverify/core/bpmn.py
@@ -2,7 +2,7 @@ from bpmncwpverify.core.error import (
     BpmnStructureError,
 )
 
-from typing import List, Dict, Union, TypeVar, Type
+from typing import List, Dict, Union, TypeVar, Type, Any
 from returns.result import Result, Failure, Success
 from bpmncwpverify.core.error import Error, BpmnUnrecognizedElement
 from xml.etree.ElementTree import Element
@@ -43,7 +43,7 @@ class BpmnElement:
         return cls(id, name, **subclass_attrs)
 
     @classmethod
-    def _extract_attributes(cls, element: Element) -> dict:
+    def _extract_attributes(cls, element: Element) -> dict[str, Any]:
         """
         Method for subclasses to add additional attributes to from_xml method
         """
@@ -151,7 +151,7 @@ class Event(Node):
         self.message_timer_definition = message_timer_definition
 
     @classmethod
-    def _extract_attributes(cls, element: Element) -> dict:
+    def _extract_attributes(cls, element: Element) -> dict[str, Any]:
         attributes = super()._extract_attributes(element)
         message_event = element.find("bpmn:messageEventDefinition", BPMN_XML_NAMESPACE)
         attributes["message_event_definition"] = (
@@ -217,7 +217,7 @@ class IntermediateEvent(Event):
         visitor.end_visit_intermediate_event(self)
 
     @classmethod
-    def _extract_attributes(cls, element: Element) -> dict:
+    def _extract_attributes(cls, element: Element) -> dict[str, Any]:
         attributes = super()._extract_attributes(element)
         tag = element.tag.partition("}")[2]
         type = "catch" if "Catch" in tag else "throw" if "Throw" in tag else "send"
@@ -250,7 +250,7 @@ class Task(Node):
             self.parent_task = parent_task
 
         @classmethod
-        def _extract_attributes(cls, element: Element) -> Dict:
+        def _extract_attributes(cls, element: Element) -> dict[str, Any]:
             attributes = super()._extract_attributes(element)
             attributes["parent_task"] = element.attrib.get("attachedToRef")
 
@@ -281,7 +281,7 @@ class Task(Node):
         visitor.end_visit_task(self)
 
     @classmethod
-    def _extract_attributes(cls, element: Element) -> dict:
+    def _extract_attributes(cls, element: Element) -> dict[str, Any]:
         attributes = super()._extract_attributes(element)
         behavior = element.find("bpmn:documentation", BPMN_XML_NAMESPACE)
         attributes["behavior"] = (

--- a/src/bpmncwpverify/core/counterexample.py
+++ b/src/bpmncwpverify/core/counterexample.py
@@ -78,12 +78,12 @@ class CounterExample:
         Extract trace steps from the filtered string.
         """
         lines = filtered_str.splitlines()
-        steps = []
+        steps: list[ErrorTrace] = []
         line_index = 0
         while line_index < len(lines):
             id = ""
-            changed_vars = []
-            curr_cwp_state = []
+            changed_vars: list[str] = []
+            curr_cwp_state: list[str] = []
             if lines[line_index].startswith("ID:"):
                 id = lines[line_index].split(" ", 1)[1].strip()
                 line_index += 1

--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -623,7 +623,7 @@ def _get_error_message(error: Error) -> str:
         case NotImplementedError(function=function):
             return "ERROR: not implemented '{}'".format(function)
         case SpinAssertionError(list_of_error_maps=list_of_error_maps):
-            errors = []
+            errors: list[str] = []
             errors.append("Assertion Error:")
             errors.append(f"{len(list_of_error_maps)} error(s) occurred:")
             for idx, map in enumerate(list_of_error_maps):

--- a/src/bpmncwpverify/core/expr.py
+++ b/src/bpmncwpverify/core/expr.py
@@ -6,7 +6,7 @@ from typing import cast
 
 from bpmncwpverify.antlr.ExprListener import ExprListener
 from bpmncwpverify.antlr.ExprLexer import ExprLexer
-from bpmncwpverify.antlr.ExprParser import ExprParser
+from bpmncwpverify.antlr.ExprParser import ExprParser  # type: ignore[attr-defined]
 from bpmncwpverify.core import typechecking
 from bpmncwpverify.core.state import (
     State,
@@ -105,7 +105,7 @@ def _parse_expressions(parser: ExprParser) -> Result[ExprParser.StartContext, Er
         return Failure(failure_value)
 
 
-class ExpressionListener(ExprListener):  # type: ignore[misc]
+class ExpressionListener(ExprListener):
     """
     Verifies expressions
     Contains interface used to interact with other classes outside of expression checking functionality

--- a/src/bpmncwpverify/visitors/bpmn_graph_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_graph_visitor.py
@@ -21,7 +21,7 @@ def dot_edge(graph: graphviz.Digraph, src: str, dst: str, label: str) -> None:
     graph.edge(src, dst, label=label)  # type: ignore[unused-ignore]
 
 
-class GraphVizVisitor(BpmnVisitor):  # type: ignore[misc]
+class GraphVizVisitor(BpmnVisitor):
     def __init__(self, process_number: int) -> None:
         self.dot = graphviz.Digraph(comment="Process graph {}".format(process_number))
 

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -160,7 +160,7 @@ class TokenPositions:
             return []
 
 
-class PromelaGenVisitor(BpmnVisitor):  # type: ignore
+class PromelaGenVisitor(BpmnVisitor):
     def __init__(self) -> None:
         self.defs = StringManager()
         self.var_defs = StringManager()
@@ -179,7 +179,7 @@ class PromelaGenVisitor(BpmnVisitor):  # type: ignore
         """
         if flow_or_message:
             return f"{element.id}_FROM_{flow_or_message.source_node.id}"
-        return element.id  # type: ignore
+        return element.id
 
     def _get_consume_locations(self, element: Node) -> TokenPositions:
         """

--- a/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidations.py
+++ b/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidations.py
@@ -37,7 +37,7 @@ from bpmncwpverify.core.error import (
 from returns.result import Result, Success, Failure
 
 
-class ProcessConnectivityVisitor(BpmnVisitor):  # type: ignore
+class ProcessConnectivityVisitor(BpmnVisitor):
     def __init__(self) -> None:
         self.visited: Set[BpmnElement] = set()
 
@@ -75,7 +75,7 @@ class ProcessConnectivityVisitor(BpmnVisitor):  # type: ignore
             raise Exception(BpmnGraphConnError())
 
 
-class ValidateSeqFlowVisitor(BpmnVisitor):  # type: ignore
+class ValidateSeqFlowVisitor(BpmnVisitor):
     def _validate_out_flows(self, gateway: GatewayNode) -> None:
         for out_flow in gateway.out_flows:
             if not out_flow.expression:
@@ -96,7 +96,7 @@ class ValidateSeqFlowVisitor(BpmnVisitor):  # type: ignore
         return True
 
 
-class ValidateMsgsVisitor(BpmnVisitor):  # type: ignore
+class ValidateMsgsVisitor(BpmnVisitor):
     def _ensure_in_messages(self, node: Event, obj_type: str) -> None:
         if node.in_msgs:
             if not node.message_event_definition:
@@ -136,7 +136,7 @@ class ValidateMsgsVisitor(BpmnVisitor):  # type: ignore
         return True
 
 
-class ValidateBpmnIncomingFlows(BpmnVisitor):  # type: ignore
+class ValidateBpmnIncomingFlows(BpmnVisitor):
     def _check_in_flows(self, element: Node) -> bool:
         if not element.in_flows:
             raise Exception(BpmnFlowIncomingError(element.id))
@@ -158,7 +158,7 @@ class ValidateBpmnIncomingFlows(BpmnVisitor):  # type: ignore
         return self._check_in_flows(gateway)
 
 
-class ValidateBpmnOutgoingFlows(BpmnVisitor):  # type: ignore
+class ValidateBpmnOutgoingFlows(BpmnVisitor):
     def _check_out_flows(self, element: Node) -> bool:
         if not element.out_flows:
             raise Exception(BpmnFlowOutgoingError(element.id))
@@ -180,7 +180,7 @@ class ValidateBpmnOutgoingFlows(BpmnVisitor):  # type: ignore
         return self._check_out_flows(gateway)
 
 
-class ValidateStartEventFlows(BpmnVisitor):  # type: ignore
+class ValidateStartEventFlows(BpmnVisitor):
     def visit_start_event(self, event: StartEvent) -> bool:
         if event.in_flows:
             raise Exception(BpmnFlowStartEventError(event.id))
@@ -191,7 +191,7 @@ class ValidateStartEventFlows(BpmnVisitor):  # type: ignore
         return False
 
 
-class SetFlowLeafs(BpmnVisitor):  # type: ignore
+class SetFlowLeafs(BpmnVisitor):
     def __init__(self) -> None:
         self.visited: Set[BpmnElement] = set()
 
@@ -229,7 +229,7 @@ class SetFlowLeafs(BpmnVisitor):  # type: ignore
         return self.process_flow(flow)
 
 
-class ValidateIdVisitor(BpmnVisitor):  # type: ignore
+class ValidateIdVisitor(BpmnVisitor):
     def _is_id_valid(self, item: BpmnElement) -> bool:
         return bool(re.fullmatch(r"[\w_-]+", item.id))
 

--- a/src/bpmncwpverify/visitors/cwp_connectivity_visitor.py
+++ b/src/bpmncwpverify/visitors/cwp_connectivity_visitor.py
@@ -3,7 +3,7 @@ from bpmncwpverify.core.cwp import Cwp, CwpState, CwpVisitor, CwpEdge
 from bpmncwpverify.core.error import CwpGraphConnError
 
 
-class CwpConnectivityVisitor(CwpVisitor):  # type: ignore
+class CwpConnectivityVisitor(CwpVisitor):
     def __init__(self) -> None:
         self.visited: Set[CwpState] = set()
 

--- a/src/bpmncwpverify/visitors/cwp_graph_visitor.py
+++ b/src/bpmncwpverify/visitors/cwp_graph_visitor.py
@@ -3,7 +3,7 @@ from bpmncwpverify.core.cwp import CwpVisitor, CwpState, CwpEdge
 from bpmncwpverify.visitors.bpmn_graph_visitor import dot_edge, dot_node
 
 
-class CwpGraphVizVisitor(CwpVisitor):  # type: ignore
+class CwpGraphVizVisitor(CwpVisitor):
     def __init__(self) -> None:
         self.dot = graphviz.Digraph(comment="cwp graph")
 

--- a/src/bpmncwpverify/visitors/cwppromelavisitor.py
+++ b/src/bpmncwpverify/visitors/cwppromelavisitor.py
@@ -11,7 +11,7 @@ END_STR = "//**********************************************//"
 PRIME_SUFFIX = "_prime"
 
 
-class CwpPromelaVisitor(CwpVisitor):  # type: ignore
+class CwpPromelaVisitor(CwpVisitor):
     def __init__(self) -> None:
         self.cwp_states = StringManager()
         self.update_state_inline = StringManager()

--- a/test/builder/test_promela_builder.py
+++ b/test/builder/test_promela_builder.py
@@ -1,16 +1,16 @@
-from bpmncwpverify.builder.filebuilder import StateBuilder
+from bpmncwpverify.builder.promela_builder import PromelaBuilder
 from bpmncwpverify.util.stringmanager import NL_SINGLE, IndentAction
 
 
 def test_logger_generator(mocker):
     mocker.patch.object(
-        StateBuilder, "variable_name_extractor", return_value=["test_string"]
+        PromelaBuilder, "variable_name_extractor", return_value=["test_string"]
     )
     mock_write_str = mocker.patch(
-        "bpmncwpverify.builder.filebuilder.StringManager.write_str"
+        "bpmncwpverify.builder.promela_builder.StringManager.write_str"
     )
 
-    sb = StateBuilder()
+    sb = PromelaBuilder()
     state = mocker.Mock()
 
     mock_val1 = mocker.Mock()
@@ -51,9 +51,9 @@ def test_variable_name_extractor(mocker):
     vars = [mocker.Mock(id=1), mocker.Mock(id=2)]
 
     state = mocker.Mock()
-    state._vars = vars
+    state.vars = vars
 
-    sb = StateBuilder()
+    sb = PromelaBuilder()
 
     result = sb.variable_name_extractor(state)
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -112,8 +112,8 @@ def test_givin_good_files_when_verify_then_output_promela(capsys):
     # then
     assert is_successful(result)
     outputs = result.unwrap()
-    assert outputs.promela is not None
-    assert outputs.promela != ""
+    assert outputs is not None
+    assert outputs != ""
 
 
 def test_good_input_webverify_output_promela():
@@ -139,8 +139,8 @@ def test_good_input_webverify_output_promela():
     # then
     assert is_successful(result)
     outputs = result.unwrap()
-    assert outputs.promela is not None
-    assert outputs.promela != ""
+    assert outputs is not None
+    assert outputs != ""
 
 
 def test_bad_input_webverify_output_error():


### PR DESCRIPTION
Fixes #265
Closes #265
Refs #270

The simple rename of `filebuilder.py` blossomed into a harder commit. The issue was type checking not being `strict`. All of the configuration changed.

`pre-commit run --all-files` works locally (rebuild container). The GitHub action will break though because paths are hardcoded in `pyrightconfig.json`. That will be addressed in issue #123.