### PR TITLE
Refactor CLI to share code with the web interface

### DIFF
--- a/src/bpmncwpverify/builder/bpmn_builder.py
+++ b/src/bpmncwpverify/builder/bpmn_builder.py
@@ -1,9 +1,10 @@
-from bpmncwpverify.core.bpmn import Bpmn, MessageFlow, Node, Process
-from bpmncwpverify.visitors.bpmnchecks.bpmnvalidate import validate_bpmn
 from returns.result import Result
+
+from bpmncwpverify.core.bpmn import Bpmn, MessageFlow, Node, Process
 from bpmncwpverify.core.error import (
     Error,
 )
+from bpmncwpverify.visitors.bpmnchecks.bpmnvalidate import validate_bpmn
 
 
 class BpmnBuilder:

--- a/src/bpmncwpverify/builder/cwp_builder.py
+++ b/src/bpmncwpverify/builder/cwp_builder.py
@@ -1,6 +1,8 @@
-from bpmncwpverify.core.state import State
-from bpmncwpverify.visitors.cwp_connectivity_visitor import CwpConnectivityVisitor
-from returns.result import Result, Success, Failure
+from returns.functions import not_
+from returns.pipeline import is_successful
+from returns.result import Failure, Result, Success
+
+from bpmncwpverify.core.cwp import Cwp, CwpEdge, CwpState
 from bpmncwpverify.core.error import (
     CwpMultStartStateError,
     CwpNoEndStatesError,
@@ -8,10 +10,9 @@ from bpmncwpverify.core.error import (
     CwpNoStartStateError,
     Error,
 )
-from bpmncwpverify.core.cwp import Cwp, CwpEdge, CwpState
 from bpmncwpverify.core.expr import ExpressionListener
-from returns.pipeline import is_successful
-from returns.functions import not_
+from bpmncwpverify.core.state import State
+from bpmncwpverify.visitors.cwp_connectivity_visitor import CwpConnectivityVisitor
 
 
 class CwpBuilder:

--- a/src/bpmncwpverify/builder/process_builder.py
+++ b/src/bpmncwpverify/builder/process_builder.py
@@ -1,14 +1,14 @@
+from typing import Union
+
+from returns.functions import not_
+from returns.pipeline import is_successful
+from returns.result import Failure, Result, Success
+
 from bpmncwpverify.core.bpmn import Node, Process, SequenceFlow, Task
+from bpmncwpverify.core.error import Error, FlowExpressionError, get_error_message
 from bpmncwpverify.core.expr import ExpressionListener
 from bpmncwpverify.core.state import State
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidate import validate_process
-from bpmncwpverify.core.error import Error, FlowExpressionError, get_error_message
-
-from returns.result import Result, Failure, Success
-from returns.pipeline import is_successful
-from returns.functions import not_
-
-from typing import Union
 
 
 class ProcessBuilder:
@@ -28,14 +28,14 @@ class ProcessBuilder:
         for bpmn_object in all_items.values():
             if isinstance(bpmn_object, Task.BoundaryEvent):
                 parent_id = bpmn_object.parent_task
-                assert (
-                    parent_id in all_items
-                ), f"Boundary event '{bpmn_object.id}' references a missing parent task ID: {parent_id}"
+                assert parent_id in all_items, (
+                    f"Boundary event '{bpmn_object.id}' references a missing parent task ID: {parent_id}"
+                )
 
                 parent_task = all_items[parent_id]
-                assert isinstance(
-                    parent_task, Task
-                ), f"Boundary event '{bpmn_object.id}' is attached to non-Task object: {type(parent_task).__name__}"
+                assert isinstance(parent_task, Task), (
+                    f"Boundary event '{bpmn_object.id}' is attached to non-Task object: {type(parent_task).__name__}"
+                )
 
                 parent_task.add_boundary_event(bpmn_object)
 
@@ -64,9 +64,9 @@ class ProcessBuilder:
                         flow_id, expression, get_error_message(result.failure())
                     )
                 )
-            assert (
-                result.unwrap() == "bool"
-            ), f"Expected Expression type to be bool on flow: {flow_id}"
+            assert result.unwrap() == "bool", (
+                f"Expected Expression type to be bool on flow: {flow_id}"
+            )
             flow.expression = expression
 
         flow.source_node = source_node

--- a/src/bpmncwpverify/client_cli/clientcli.py
+++ b/src/bpmncwpverify/client_cli/clientcli.py
@@ -1,12 +1,12 @@
 import argparse
 import builtins
-from returns.pipeline import is_successful
-from returns.functions import not_
-from returns.io import impure_safe, IOResultE
-from returns.pipeline import managed, flow
-from returns.result import ResultE, Result, Success, Failure
 from typing import TextIO
+
 import requests
+from returns.functions import not_
+from returns.io import IOResultE, impure_safe
+from returns.pipeline import flow, is_successful, managed
+from returns.result import Failure, Result, ResultE, Success
 from returns.unsafe import unsafe_perform_io
 
 LAMBDA_URL = "https://cxvqggpd6swymxnmahwvgfsina0tiokb.lambda-url.us-east-1.on.aws/"

--- a/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
@@ -1,21 +1,21 @@
-from bpmncwpverify.builder.bpmn_builder import BpmnBuilder
-from bpmncwpverify.core.accessmethods.processmethods import from_xml as process_from_xml
-from bpmncwpverify.core.bpmn import (
-    Bpmn,
-    BPMN_XML_NAMESPACE,
-    MessageFlow,
-)
-from bpmncwpverify.core.error import Error
-from bpmncwpverify.core.state import State
-from bpmncwpverify.visitors.bpmn_promela_visitor import PromelaGenVisitor
-from bpmncwpverify.visitors.bpmn_graph_visitor import GraphVizVisitor
+from typing import cast
+from xml.etree.ElementTree import Element
 
 from returns.functions import not_
 from returns.pipeline import is_successful
 from returns.result import Result
 
-from typing import cast
-from xml.etree.ElementTree import Element
+from bpmncwpverify.builder.bpmn_builder import BpmnBuilder
+from bpmncwpverify.core.accessmethods.processmethods import from_xml as process_from_xml
+from bpmncwpverify.core.bpmn import (
+    BPMN_XML_NAMESPACE,
+    Bpmn,
+    MessageFlow,
+)
+from bpmncwpverify.core.error import Error
+from bpmncwpverify.core.state import State
+from bpmncwpverify.visitors.bpmn_graph_visitor import GraphVizVisitor
+from bpmncwpverify.visitors.bpmn_promela_visitor import PromelaGenVisitor
 
 
 def generate_promela(bpmn: Bpmn) -> str:

--- a/src/bpmncwpverify/core/accessmethods/cwpmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/cwpmethods.py
@@ -1,16 +1,18 @@
 from typing import List
 from xml.etree.ElementTree import Element
-from bpmncwpverify.core.expr import ExpressionListener
-from bpmncwpverify.core.state import State
-from returns.result import Result, Failure
+
+from returns.result import Failure, Result
+
+from bpmncwpverify.builder.cwp_builder import CwpBuilder
+from bpmncwpverify.core.cwp import Cwp, CwpEdge, CwpState
 from bpmncwpverify.core.error import (
     CwpEdgeNoParentExprError,
     CwpEdgeNoStateError,
     CwpFileStructureError,
     Error,
 )
-from bpmncwpverify.core.cwp import Cwp, CwpState, CwpEdge
-from bpmncwpverify.builder.cwp_builder import CwpBuilder
+from bpmncwpverify.core.expr import ExpressionListener
+from bpmncwpverify.core.state import State
 from bpmncwpverify.visitors.cwp_graph_visitor import CwpGraphVizVisitor
 from bpmncwpverify.visitors.cwppromelavisitor import CwpPromelaVisitor
 

--- a/src/bpmncwpverify/core/accessmethods/processmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/processmethods.py
@@ -1,18 +1,20 @@
-from xml.etree.ElementTree import Element
 from typing import Union
-from bpmncwpverify.core.state import State
-from returns.result import Result, Failure
-from bpmncwpverify.core.error import Error
+from xml.etree.ElementTree import Element
+
+from returns.functions import not_
+from returns.pipeline import is_successful
+from returns.result import Failure, Result
+
 from bpmncwpverify.builder.process_builder import ProcessBuilder
 from bpmncwpverify.core.bpmn import (
-    Process,
-    get_element_type,
     BPMN_XML_NAMESPACE,
-    SequenceFlow,
     Node,
+    Process,
+    SequenceFlow,
+    get_element_type,
 )
-from returns.pipeline import is_successful
-from returns.functions import not_
+from bpmncwpverify.core.error import Error
+from bpmncwpverify.core.state import State
 
 
 def from_xml(element: Element, state: State) -> Result["Process", Error]:

--- a/src/bpmncwpverify/core/bpmn.py
+++ b/src/bpmncwpverify/core/bpmn.py
@@ -1,12 +1,13 @@
-from bpmncwpverify.core.error import (
-    BpmnStructureError,
-)
-
-from typing import List, Dict, Union, TypeVar, Type, Any
-from returns.result import Result, Failure, Success
-from bpmncwpverify.core.error import Error, BpmnUnrecognizedElement
+from typing import Any, Dict, List, Type, TypeVar, Union
 from xml.etree.ElementTree import Element
 
+from returns.result import Failure, Result, Success
+
+from bpmncwpverify.core.error import (
+    BpmnStructureError,
+    BpmnUnrecognizedElement,
+    Error,
+)
 
 BPMN_XML_NAMESPACE = {"bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL"}
 
@@ -254,9 +255,9 @@ class Task(Node):
             attributes = super()._extract_attributes(element)
             attributes["parent_task"] = element.attrib.get("attachedToRef")
 
-            assert attributes[
-                "parent_task"
-            ], f"Boundary Event: {element.attrib.get("id")} has no parent"
+            assert attributes["parent_task"], (
+                f"Boundary Event: {element.attrib.get('id')} has no parent"
+            )
 
             return attributes
 

--- a/src/bpmncwpverify/core/counterexample.py
+++ b/src/bpmncwpverify/core/counterexample.py
@@ -1,9 +1,9 @@
-from bpmncwpverify.core.error import Error
-from bpmncwpverify.util.stringmanager import StringManager, NL_SINGLE
-from typing import Type
-
 import json
 import subprocess
+from typing import Type
+
+from bpmncwpverify.core.error import Error
+from bpmncwpverify.util.stringmanager import NL_SINGLE, StringManager
 
 
 class ErrorTrace:
@@ -87,20 +87,20 @@ class CounterExample:
             if lines[line_index].startswith("ID:"):
                 id = lines[line_index].split(" ", 1)[1].strip()
                 line_index += 1
-                assert line_index < len(
-                    lines
-                ), "line_index should never be out of bounds"
+                assert line_index < len(lines), (
+                    "line_index should never be out of bounds"
+                )
                 if lines[line_index].startswith("Changed vars:"):
                     line_index += 1
-                    assert line_index < len(
-                        lines
-                    ), "line_index should never be out of bounds"
+                    assert line_index < len(lines), (
+                        "line_index should never be out of bounds"
+                    )
                     while not lines[line_index].startswith("Current state:"):
                         changed_vars.append(lines[line_index].strip())
                         line_index += 1
-                        assert line_index < len(
-                            lines
-                        ), "line_index should never be out of bounds"
+                        assert line_index < len(lines), (
+                            "line_index should never be out of bounds"
+                        )
                     while line_index < len(lines) and lines[line_index].startswith(
                         "Current state:"
                     ):

--- a/src/bpmncwpverify/core/cwp.py
+++ b/src/bpmncwpverify/core/cwp.py
@@ -1,6 +1,6 @@
+import re
 from typing import Dict, List, Optional
 from xml.etree.ElementTree import Element
-import re
 
 
 class Cwp:

--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -328,6 +328,30 @@ class ExpressionUnrecognizedID(Error):
         return False
 
 
+class FileReadFileError(Error):
+    __slots__ = ["msg"]
+
+    def __init__(self, msg: str) -> None:
+        super().__init__()
+        self.msg = msg
+
+
+class FileWriteFileError(Error):
+    __slots__ = ["msg"]
+
+    def __init__(self, msg: str):
+        super().__init__()
+        self.msg = msg
+
+
+class FileXmlParseError(Error):
+    __slots__ = ["msg"]
+
+    def __init__(self, msg: str):
+        super().__init__()
+        self.msg = msg
+
+
 class FlowExpressionError(Error):
     __slots__ = ["flow_id", "expression", "exception_str"]
 
@@ -345,14 +369,6 @@ class MessageError(Error):
         super().__init__()
         self.node_id = node_id
         self.error_msg = error_msg
-
-
-class MissingFileError(Error):
-    __slots__ = ["file_name"]
-
-    def __init__(self, file_name: str) -> None:
-        super().__init__()
-        self.file_name = file_name
 
 
 class NotImplementedError(Error):
@@ -540,14 +556,6 @@ class TypingNotNonBoolError(Error):
         self.expr_type = expr_type
 
 
-class WriteFileError(Error):
-    __slots__ = ["msg"]
-
-    def __init__(self, msg: str):
-        super().__init__()
-        self.msg = msg
-
-
 def _get_exception_message(error: Exception) -> str:
     return "ERROR: {0} ({1})".format(type(error), error)
 
@@ -636,14 +644,18 @@ def _get_error_message(error: Error) -> str:
             return "EXPR ERROR: '{}' is not recognized as a literal or something stored in the symbol table".format(
                 _id
             )
+        case FileReadFileError(msg=msg):
+            return "FILE ERROR: '{}'".format(msg)
+        case FileWriteFileError(msg=msg):
+            return "FILE ERROR: '{}'".format(msg)
+        case FileXmlParseError(msg=msg):
+            return "FILE ERROR: '{}'".format(msg)
         case FlowExpressionError(
             flow_id=flow_id, expression=expression, exception_str=exception_str
         ):
             return f"Error occurred while parsing the expression on flow: '{flow_id}' with expression: '{expression}':\n\t'{exception_str}'"
         case MessageError(node_id=node_id, error_msg=error_msg):
             return f"Inter-process message error at node: {node_id}. {error_msg}"
-        case MissingFileError(file_name=file_name):
-            return f"Could not find file with name {file_name}"
         case NotImplementedError(function=function):
             return "ERROR: not implemented '{}'".format(function)
         case NotInitializedError(var_name=var_name):
@@ -715,8 +727,6 @@ def _get_error_message(error: Error) -> str:
             )
         case TypingNoTypeError(id=id):
             return "TYPING ERROR: literal '{}' has an unknown type".format(id)
-        case WriteFileError(msg=msg):
-            return "WRITE FILE ERROR: '{}'".format(msg)
 
         case _:
             raise builtins.NotImplementedError

--- a/src/bpmncwpverify/core/expr.py
+++ b/src/bpmncwpverify/core/expr.py
@@ -1,35 +1,32 @@
+from typing import Any, List, cast
+
 from antlr4 import CommonTokenStream, InputStream, ParseTreeWalker
-from antlr4.error.ErrorStrategy import ParseCancellationException
 from antlr4.error.ErrorListener import ConsoleErrorListener, ErrorListener
+from antlr4.error.ErrorStrategy import ParseCancellationException
+from returns.curry import partial
+from returns.functions import not_
+from returns.pipeline import flow, is_successful
+from returns.pointfree import bind_result
+from returns.result import Failure, Result, Success
 
-from typing import cast
-
-from bpmncwpverify.antlr.ExprListener import ExprListener
 from bpmncwpverify.antlr.ExprLexer import ExprLexer
+from bpmncwpverify.antlr.ExprListener import ExprListener
 from bpmncwpverify.antlr.ExprParser import ExprParser  # type: ignore[attr-defined]
 from bpmncwpverify.core import typechecking
+from bpmncwpverify.core.error import (
+    Error,
+    ExpressionComputationCompatabilityError,
+    ExpressionNegatorError,
+    ExpressionParseError,
+    ExpressionRelationalNotError,
+    ExpressionRelationCompatabilityError,
+    ExpressionUnrecognizedID,
+)
 from bpmncwpverify.core.state import (
     State,
     antlr_get_terminal_node_impl,
     antlr_get_text,
 )
-from bpmncwpverify.core.error import (
-    Error,
-    ExpressionComputationCompatabilityError,
-    ExpressionParseError,
-    ExpressionRelationCompatabilityError,
-    ExpressionRelationalNotError,
-    ExpressionNegatorError,
-    ExpressionUnrecognizedID,
-)
-
-from returns.result import Failure, Result, Success
-from returns.pipeline import flow, is_successful
-from returns.pointfree import bind_result
-from returns.curry import partial
-from returns.functions import not_
-
-from typing import Any, List
 
 
 class ThrowingErrorListener(ErrorListener):  # type: ignore[misc]

--- a/src/bpmncwpverify/core/state.py
+++ b/src/bpmncwpverify/core/state.py
@@ -1,24 +1,21 @@
+from typing import Any, Iterable, List, Protocol, cast
+
 from antlr4 import CommonTokenStream, InputStream, ParseTreeWalker
 from antlr4.error.ErrorListener import ConsoleErrorListener, ErrorListener
 from antlr4.error.ErrorStrategy import ParseCancellationException
 from antlr4.Token import Token
 from antlr4.tree.Tree import TerminalNode, TerminalNodeImpl
-
+from returns.curry import partial
+from returns.functions import not_
 from returns.maybe import Maybe, Nothing, Some
-from returns.result import Failure, Result, Success
 from returns.pipeline import flow, is_successful
 from returns.pointfree import bind_result
-from returns.functions import not_
-from returns.curry import partial
-
-from typing import Any, List, cast, Iterable, Protocol
+from returns.result import Failure, Result, Success
 
 from bpmncwpverify.antlr.StateLexer import StateLexer
 from bpmncwpverify.antlr.StateListener import StateListener
 from bpmncwpverify.antlr.StateParser import StateParser  # type: ignore[attr-defined]
-
 from bpmncwpverify.core import typechecking
-
 from bpmncwpverify.core.error import (
     Error,
     StateInitNotInValues,

--- a/src/bpmncwpverify/core/typechecking.py
+++ b/src/bpmncwpverify/core/typechecking.py
@@ -1,5 +1,6 @@
+from typing import Callable, Final
+
 from returns.result import Failure, Result, Success
-from typing import Final, Callable
 
 from bpmncwpverify.core.error import (
     Error,

--- a/src/bpmncwpverify/util/stringmanager.py
+++ b/src/bpmncwpverify/util/stringmanager.py
@@ -1,5 +1,5 @@
-from typing import List, Union
 from enum import Enum
+from typing import List, Union
 
 NL_NONE = 0
 NL_SINGLE = 1

--- a/src/bpmncwpverify/visitors/bpmn_graph_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_graph_visitor.py
@@ -1,15 +1,16 @@
 import graphviz
+
 from bpmncwpverify.core.bpmn import (
-    StartEvent,
+    Bpmn,
+    BpmnVisitor,
     EndEvent,
+    ExclusiveGatewayNode,
     IntermediateEvent,
-    Task,
-    SequenceFlow,
     MessageFlow,
     ParallelGatewayNode,
-    ExclusiveGatewayNode,
-    BpmnVisitor,
-    Bpmn,
+    SequenceFlow,
+    StartEvent,
+    Task,
 )
 
 

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -1,19 +1,20 @@
 from typing import List, Optional
+
 from bpmncwpverify.core.bpmn import (
-    Flow,
-    Node,
-    StartEvent,
-    EndEvent,
-    IntermediateEvent,
-    Task,
-    MessageFlow,
-    ParallelGatewayNode,
-    ExclusiveGatewayNode,
-    BpmnVisitor,
-    Process,
     Bpmn,
+    BpmnVisitor,
+    EndEvent,
+    ExclusiveGatewayNode,
+    Flow,
+    IntermediateEvent,
+    MessageFlow,
+    Node,
+    ParallelGatewayNode,
+    Process,
+    StartEvent,
+    Task,
 )
-from bpmncwpverify.util.stringmanager import StringManager, IndentAction
+from bpmncwpverify.util.stringmanager import IndentAction, StringManager
 
 ##############
 # Constants
@@ -71,9 +72,9 @@ class Context:
 
     @is_parallel.setter
     def is_parallel(self, new_val: bool) -> None:
-        assert isinstance(
-            self._element, ParallelGatewayNode
-        ), "is_parallel can only be set if element is of type ParallelGatewayNode"
+        assert isinstance(self._element, ParallelGatewayNode), (
+            "is_parallel can only be set if element is of type ParallelGatewayNode"
+        )
         self._is_parallel = new_val
 
     @property
@@ -82,9 +83,9 @@ class Context:
 
     @behavior.setter
     def behavior(self, new_val: str) -> None:
-        assert isinstance(
-            self._element, Task
-        ), "only tasks can have a behavior associated with them."
+        assert isinstance(self._element, Task), (
+            "only tasks can have a behavior associated with them."
+        )
         self._behavior = new_val
 
     @property
@@ -93,9 +94,9 @@ class Context:
 
     @end_event.setter
     def end_event(self, new_val: bool) -> None:
-        assert isinstance(
-            self._element, EndEvent
-        ), "end_event can only be set if element is of type EndEvent"
+        assert isinstance(self._element, EndEvent), (
+            "end_event can only be set if element is of type EndEvent"
+        )
         self._end_event = new_val
 
     @property
@@ -104,9 +105,9 @@ class Context:
 
     @boundary_events.setter
     def boundary_events(self, new_val: List[Task.BoundaryEvent]) -> None:
-        assert isinstance(
-            self._element, Task
-        ), "Only allowed to set boundary_events on a task."
+        assert isinstance(self._element, Task), (
+            "Only allowed to set boundary_events on a task."
+        )
         self._boundary_events = new_val
 
     @property
@@ -225,7 +226,7 @@ class PromelaGenVisitor(BpmnVisitor):
                 self._get_expressions(ctx), self._get_put_locations(ctx.element)
             ):
                 sm.write_str(
-                    f":: {expression.replace("\n", "")} -> putToken({location})",
+                    f":: {expression.replace('\n', '')} -> putToken({location})",
                     NL_SINGLE,
                 )
         if ctx.boundary_events:

--- a/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidate.py
+++ b/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidate.py
@@ -1,3 +1,7 @@
+from returns.pipeline import flow
+from returns.pointfree import bind_result
+from returns.result import Failure, Result, Success
+
 from bpmncwpverify.core.bpmn import Bpmn, Process
 from bpmncwpverify.core.error import BpmnMsgFlowSamePoolError, Error
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidations import (
@@ -6,16 +10,13 @@ from bpmncwpverify.visitors.bpmnchecks.bpmnvalidations import (
 from bpmncwpverify.visitors.bpmnchecks.checkmethods import (
     check_connectivity,
     set_leaf_flows,
+    validate_bpmn_ids,
     validate_bpmn_incoming_flows,
     validate_bpmn_outgoing_flows,
-    validate_start_event_flows,
-    validate_bpmn_ids,
     validate_msgs,
     validate_seq_flows,
+    validate_start_event_flows,
 )
-from returns.result import Result, Failure, Success
-from returns.pipeline import flow
-from returns.pointfree import bind_result
 
 
 def validate_bpmn(bpmn: Bpmn) -> Result[Bpmn, Error]:

--- a/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidations.py
+++ b/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidations.py
@@ -1,27 +1,31 @@
-from typing import Set
 import re
+from typing import Set
+
+from returns.result import Failure, Result, Success
+
 from bpmncwpverify.core.bpmn import (
     BpmnElement,
     BpmnVisitor,
+    EndEvent,
+    Event,
+    ExclusiveGatewayNode,
     Flow,
     GatewayNode,
+    IntermediateEvent,
     MessageFlow,
     Node,
+    ParallelGatewayNode,
     Process,
     SequenceFlow,
     StartEvent,
-    EndEvent,
-    Event,
-    IntermediateEvent,
     Task,
-    ExclusiveGatewayNode,
-    ParallelGatewayNode,
 )
 from bpmncwpverify.core.error import (
     BpmnFlowIncomingError,
     BpmnFlowOutgoingError,
     BpmnFlowStartEventError,
     BpmnGraphConnError,
+    BpmnInvalidIdError,
     BpmnMissingEventsError,
     BpmnMsgEndEventError,
     BpmnMsgGatewayError,
@@ -31,10 +35,8 @@ from bpmncwpverify.core.error import (
     BpmnSeqFlowEndEventError,
     BpmnSeqFlowNoExprError,
     BpmnTaskFlowError,
-    BpmnInvalidIdError,
     Error,
 )
-from returns.result import Result, Success, Failure
 
 
 class ProcessConnectivityVisitor(BpmnVisitor):

--- a/src/bpmncwpverify/visitors/bpmnchecks/checkmethods.py
+++ b/src/bpmncwpverify/visitors/bpmnchecks/checkmethods.py
@@ -1,3 +1,5 @@
+from returns.result import Failure, Result, Success
+
 from bpmncwpverify.core.bpmn import BpmnVisitor, Process
 from bpmncwpverify.core.error import Error
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidations import (
@@ -5,12 +7,11 @@ from bpmncwpverify.visitors.bpmnchecks.bpmnvalidations import (
     SetFlowLeafs,
     ValidateBpmnIncomingFlows,
     ValidateBpmnOutgoingFlows,
+    ValidateIdVisitor,
     ValidateMsgsVisitor,
     ValidateSeqFlowVisitor,
     ValidateStartEventFlows,
-    ValidateIdVisitor,
 )
-from returns.result import Result, Success, Failure
 
 
 def validate_process_with_visitor(

--- a/src/bpmncwpverify/visitors/cwp_connectivity_visitor.py
+++ b/src/bpmncwpverify/visitors/cwp_connectivity_visitor.py
@@ -1,5 +1,6 @@
 from typing import Set
-from bpmncwpverify.core.cwp import Cwp, CwpState, CwpVisitor, CwpEdge
+
+from bpmncwpverify.core.cwp import Cwp, CwpEdge, CwpState, CwpVisitor
 from bpmncwpverify.core.error import CwpGraphConnError
 
 

--- a/src/bpmncwpverify/visitors/cwp_graph_visitor.py
+++ b/src/bpmncwpverify/visitors/cwp_graph_visitor.py
@@ -1,5 +1,6 @@
 import graphviz
-from bpmncwpverify.core.cwp import CwpVisitor, CwpState, CwpEdge
+
+from bpmncwpverify.core.cwp import CwpEdge, CwpState, CwpVisitor
 from bpmncwpverify.visitors.bpmn_graph_visitor import dot_edge, dot_node
 
 

--- a/src/bpmncwpverify/visitors/cwppromelavisitor.py
+++ b/src/bpmncwpverify/visitors/cwppromelavisitor.py
@@ -1,9 +1,9 @@
 from bpmncwpverify.core.cwp import Cwp, CwpEdge, CwpState, CwpVisitor
 from bpmncwpverify.util.stringmanager import (
-    StringManager,
-    NL_SINGLE,
     NL_DOUBLE,
+    NL_SINGLE,
     IndentAction,
+    StringManager,
 )
 
 START_STR = "//**********CWP VARIABLE DECLARATION************//"

--- a/test/builder/test_bpmn_builder.py
+++ b/test/builder/test_bpmn_builder.py
@@ -1,6 +1,8 @@
 # type: ignore
-import pytest
 from xml.etree.ElementTree import Element
+
+import pytest
+
 from bpmncwpverify.builder.bpmn_builder import BpmnBuilder
 from bpmncwpverify.core.bpmn import Node
 

--- a/test/builder/test_cwp_builder.py
+++ b/test/builder/test_cwp_builder.py
@@ -1,15 +1,15 @@
 # type: ignore
+import pytest
+from returns.functions import not_
+from returns.pipeline import is_successful
+from returns.result import Success
+
 from bpmncwpverify.builder.cwp_builder import CwpBuilder
 from bpmncwpverify.core.cwp import Cwp, CwpEdge, CwpState
 from bpmncwpverify.core.error import (
     CwpNoParentEdgeError,
     CwpNoStartStateError,
 )
-from returns.result import Success
-import pytest
-
-from returns.pipeline import is_successful
-from returns.functions import not_
 
 
 @pytest.fixture

--- a/test/builder/test_process_builder.py
+++ b/test/builder/test_process_builder.py
@@ -1,9 +1,10 @@
 # type: ignore
 import pytest
+from returns.result import Success
+
 from bpmncwpverify.builder.process_builder import ProcessBuilder
 from bpmncwpverify.core.bpmn import Node, SequenceFlow, Task
 from bpmncwpverify.core.state import State
-from returns.result import Success
 
 
 def test_add_element(mocker):

--- a/test/client_cli/test_clientcli.py
+++ b/test/client_cli/test_clientcli.py
@@ -1,21 +1,24 @@
 # type: ignore
+import sys
+
+import pytest
+from requests.exceptions import HTTPError as httperr
+from requests.exceptions import RequestException
+from returns.result import Failure, Success
+
 from bpmncwpverify.client_cli.clientcli import (
-    _verify,
-    get_error_message,
-    _trigger_lambda,
-    _with_file,
-    FileOpenError,
     Error,
     FileError,
-    RequestError,
+    FileOpenError,
     HTTPError,
     Outputs,
+    RequestError,
+    _trigger_lambda,
+    _verify,
+    _with_file,
     cli_verify,
+    get_error_message,
 )
-from returns.result import Success, Failure
-import sys
-import pytest
-from requests.exceptions import RequestException, HTTPError as httperr
 
 
 def test_givin_good_state_expect_good_response(mocker):

--- a/test/core/accessmethods/test_cwpmethods.py
+++ b/test/core/accessmethods/test_cwpmethods.py
@@ -1,12 +1,13 @@
+import pytest
+from returns.functions import not_
+from returns.pipeline import is_successful
+
 from bpmncwpverify.core.accessmethods.cwpmethods import CwpXmlParser
 from bpmncwpverify.core.error import (
-    CwpFileStructureError,
-    CwpEdgeNoStateError,
     CwpEdgeNoParentExprError,
+    CwpEdgeNoStateError,
+    CwpFileStructureError,
 )
-import pytest
-from returns.pipeline import is_successful
-from returns.functions import not_
 
 
 class TestCwpXmlParser:

--- a/test/core/test_bpmn.py
+++ b/test/core/test_bpmn.py
@@ -1,11 +1,13 @@
 # type: ignore
 from xml.etree.ElementTree import Element, SubElement, tostring
+
 from defusedxml import ElementTree
-from bpmncwpverify.core.bpmn import BPMN_XML_NAMESPACE, StartEvent
-from bpmncwpverify.core.accessmethods.bpmnmethods import from_xml
-from bpmncwpverify.core.state import StateBuilder
-from bpmncwpverify.core.error import BpmnMissingEventsError
 from returns.result import Failure, Success
+
+from bpmncwpverify.core.accessmethods.bpmnmethods import from_xml
+from bpmncwpverify.core.bpmn import BPMN_XML_NAMESPACE, StartEvent
+from bpmncwpverify.core.error import BpmnMissingEventsError
+from bpmncwpverify.core.state import StateBuilder
 
 
 def create_bpmn_definition():

--- a/test/core/test_counterexample.py
+++ b/test/core/test_counterexample.py
@@ -1,6 +1,7 @@
-from bpmncwpverify.core.counterexample import CounterExample, NL_SINGLE
-from bpmncwpverify.core.error import Error
 import pytest
+
+from bpmncwpverify.core.counterexample import NL_SINGLE, CounterExample
+from bpmncwpverify.core.error import Error
 
 
 @pytest.fixture

--- a/test/core/test_cwp.py
+++ b/test/core/test_cwp.py
@@ -1,18 +1,19 @@
 # type: ignore
 from xml.etree.ElementTree import Element, SubElement
 
+import pytest
+from returns.functions import not_
+from returns.pipeline import is_successful
+
+from bpmncwpverify.core.accessmethods.cwpmethods import CwpXmlParser
+from bpmncwpverify.core.cwp import CwpEdge, CwpState
 from bpmncwpverify.core.error import (
     CwpMultStartStateError,
     CwpNoEndStatesError,
     CwpNoStartStateError,
     Error,
 )
-from returns.functions import not_
 from bpmncwpverify.core.state import State
-from returns.pipeline import is_successful
-from bpmncwpverify.core.accessmethods.cwpmethods import CwpXmlParser
-from bpmncwpverify.core.cwp import CwpEdge, CwpState
-import pytest
 
 
 def get_root_mx_root():

--- a/test/core/test_error.py
+++ b/test/core/test_error.py
@@ -42,9 +42,11 @@ from bpmncwpverify.core.error import (
     ExpressionRelationalNotError,
     ExpressionRelationCompatabilityError,
     ExpressionUnrecognizedID,
+    FileReadFileError,
+    FileWriteFileError,
+    FileXmlParseError,
     FlowExpressionError,
     MessageError,
-    MissingFileError,
     NotImplementedError,
     NotInitializedError,
     SpinAssertionError,
@@ -57,7 +59,6 @@ from bpmncwpverify.core.error import (
     SubProcessRunError,
     TypingAssignCompatabilityError,
     TypingNoTypeError,
-    WriteFileError,
     get_error_message,
 )
 
@@ -207,16 +208,18 @@ test_inputs: list[tuple[Error, str]] = [
         "EXPR ERROR: '_id' is not recognized as a literal or something stored in the symbol table",
     ),
     (
+        FileReadFileError("file_name"),
+        "FILE ERROR: 'file_name'",
+    ),
+    (FileWriteFileError("a"), "FILE ERROR: 'a'"),
+    (FileXmlParseError("a"), "FILE ERROR: 'a'"),
+    (
         FlowExpressionError("flow_id", "expression", "exception_str"),
         "Error occurred while parsing the expression on flow: 'flow_id' with expression: 'expression':\n\t'exception_str'",
     ),
     (
         MessageError("node_id", "error_msg"),
         "Inter-process message error at node: node_id. error_msg",
-    ),
-    (
-        MissingFileError("file_name"),
-        "Could not find file with name file_name",
     ),
     (NotImplementedError("notImplemented"), "ERROR: not implemented 'notImplemented'"),
     (
@@ -288,7 +291,6 @@ test_inputs: list[tuple[Error, str]] = [
     ),
     (SubProcessRunError("proc"), "ERROR: failed to run 'proc'"),
     (TypingNoTypeError("a"), "TYPING ERROR: literal 'a' has an unknown type"),
-    (WriteFileError("a"), "WRITE FILE ERROR: 'a'"),
 ]
 
 test_ids: list[str] = [
@@ -328,9 +330,11 @@ test_ids: list[str] = [
     "ExpressionRelationCompatabilityError",
     "ExpressionRelationalNotError",
     "ExpressionUnrecognizedID",
+    "FileReadFileError",
+    "FileWriteFileError",
+    "FileXmlParseError",
     "FlowExpressionError",
     "MessageError",
-    "MissingFileError",
     "NotImplementedError",
     "NotInitializedError",
     "SpinAssertionError",
@@ -346,7 +350,6 @@ test_ids: list[str] = [
     "SubprocessRunError",
     "TypeingAssignCompatabilityError",
     "TypingNoTypeError",
-    "WriteFileError",
 ]
 
 

--- a/test/core/test_expr_interface.py
+++ b/test/core/test_expr_interface.py
@@ -1,17 +1,16 @@
 # type: ignore
-from bpmncwpverify.core.expr import ExpressionListener
-from bpmncwpverify.core.state import State
+import pytest
+from returns.pipeline import is_successful
+
 from bpmncwpverify.core.error import (
     ExpressionComputationCompatabilityError,
     ExpressionNegatorError,
-    ExpressionRelationCompatabilityError,
     ExpressionRelationalNotError,
+    ExpressionRelationCompatabilityError,
     ExpressionUnrecognizedID,
 )
-
-from returns.pipeline import is_successful
-
-import pytest
+from bpmncwpverify.core.expr import ExpressionListener
+from bpmncwpverify.core.state import State
 
 
 @pytest.mark.parametrize(

--- a/test/core/test_expr_parser.py
+++ b/test/core/test_expr_parser.py
@@ -1,13 +1,11 @@
 # type: ignore
-from antlr4.error.ErrorStrategy import ParseCancellationException
-
-from bpmncwpverify.core.expr import _get_parser
+from typing import Iterable
 
 import pytest
-
+from antlr4.error.ErrorStrategy import ParseCancellationException
 from returns.pipeline import is_successful
 
-from typing import Iterable
+from bpmncwpverify.core.expr import _get_parser
 
 
 @pytest.fixture(scope="module")

--- a/test/core/test_state.py
+++ b/test/core/test_state.py
@@ -1,28 +1,25 @@
 # type: ignore
-import pytest
-
-from antlr4.error.ErrorStrategy import ParseCancellationException
-from returns.pipeline import is_successful
-from returns.result import Result
-from returns.functions import not_
-from returns.maybe import Some
-
+import re
 from typing import Iterable
 
+import pytest
+from antlr4.error.ErrorStrategy import ParseCancellationException
+from returns.functions import not_
+from returns.maybe import Some
+from returns.pipeline import is_successful
+from returns.result import Result
+
 from bpmncwpverify.antlr.StateParser import StateParser
+from bpmncwpverify.core import typechecking
 from bpmncwpverify.core.error import (
     Error,
-    StateSyntaxError,
     StateInitNotInValues,
     StateMultipleDefinitionError,
-    TypingNoTypeError,
+    StateSyntaxError,
     TypingAssignCompatabilityError,
+    TypingNoTypeError,
 )
-
-from bpmncwpverify.core.state import _get_parser, _parse_state, State
-from bpmncwpverify.core import typechecking
-
-import re
+from bpmncwpverify.core.state import State, _get_parser, _parse_state
 
 
 @pytest.fixture(scope="module")

--- a/test/core/test_typechecking.py
+++ b/test/core/test_typechecking.py
@@ -1,16 +1,14 @@
 # type: ignore
+import pytest
 from returns.result import Failure, Success
 
-import pytest
-
-from bpmncwpverify.core.error import TypingNoTypeError, TypingAssignCompatabilityError
-
+from bpmncwpverify.core.error import TypingAssignCompatabilityError, TypingNoTypeError
 from bpmncwpverify.core.typechecking import (
     BIT,
     BOOL,
     BYTE,
-    SHORT,
     INT,
+    SHORT,
     get_type_assign,
     get_type_literal,
 )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,8 +7,8 @@ from returns.pipeline import is_successful
 from returns.result import Success
 from returns.unsafe import unsafe_perform_io
 
-from bpmncwpverify.cli import verify_result, web_verify
-from bpmncwpverify.core.error import Error, MissingFileError, StateSyntaxError
+from bpmncwpverify.cli import verify_with_spin, web_verify
+from bpmncwpverify.core.error import Error, FileReadFileError, StateSyntaxError
 from bpmncwpverify.core.state import State
 
 
@@ -22,7 +22,7 @@ def mock_state(mocker):
     return state
 
 
-def test_givin_bad_state_file_path_when_get_promela_then_io_error(capsys):
+def test_givin_bad_state_file_path_when_verify_then_io_error(capsys):
     # given
     test_args = [
         "verify",
@@ -33,16 +33,15 @@ def test_givin_bad_state_file_path_when_get_promela_then_io_error(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_result(test_args[1], test_args[2], test_args[3])
+    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
 
     # then
     assert not_(is_successful)(result)
     error: Error = unsafe_perform_io(result.failure())
-    assert isinstance(error, MissingFileError)
-    assert error.file_name == "state.txt"
+    assert isinstance(error, FileReadFileError)
 
 
-def test_givin_bad_cwp_file_path_when_get_promela_then_io_error(capsys):
+def test_givin_bad_cwp_file_path_when_verify_then_io_error(capsys):
     # given
     test_args = [
         "verify",
@@ -53,16 +52,15 @@ def test_givin_bad_cwp_file_path_when_get_promela_then_io_error(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_result(test_args[1], test_args[2], test_args[3])
+    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
 
     # then
     assert not_(is_successful)(result)
     error: Error = unsafe_perform_io(result.failure())
-    assert isinstance(error, MissingFileError)
-    assert error.file_name == "test_cwp.xml"
+    assert isinstance(error, FileReadFileError)
 
 
-def test_givin_bad_bpmn_file_path_when_get_promela_then_io_error(capsys):
+def test_givin_bad_bpmn_file_path_when_verify_then_io_error(capsys):
     # given
     test_args = [
         "verify",
@@ -73,16 +71,15 @@ def test_givin_bad_bpmn_file_path_when_get_promela_then_io_error(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_result(test_args[1], test_args[2], test_args[3])
+    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
 
     # then
     assert not_(is_successful)(result)
     error: Error = unsafe_perform_io(result.failure())
-    assert isinstance(error, MissingFileError)
-    assert error.file_name == "test_bpmn.bpmn"
+    assert isinstance(error, FileReadFileError)
 
 
-def test_givin_bad_state_file_when_get_promela_then_state_errror(capsys):
+def test_givin_bad_state_file_when_verify_then_state_errror(capsys):
     # given
     test_args = [
         "verify",
@@ -93,7 +90,7 @@ def test_givin_bad_state_file_when_get_promela_then_state_errror(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_result(test_args[1], test_args[2], test_args[3])
+    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
 
     # then
     assert not_(is_successful)(result)
@@ -101,7 +98,7 @@ def test_givin_bad_state_file_when_get_promela_then_state_errror(capsys):
     assert isinstance(error, StateSyntaxError)
 
 
-def test_givin_good_files_when_get_promela_then_output_promela(capsys):
+def test_givin_good_files_when_verify_then_success(capsys):
     # given
     test_args = [
         "verify",
@@ -112,7 +109,7 @@ def test_givin_good_files_when_get_promela_then_output_promela(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_result(test_args[1], test_args[2], test_args[3])
+    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
 
     # then
     assert is_successful(result)
@@ -121,7 +118,7 @@ def test_givin_good_files_when_get_promela_then_output_promela(capsys):
     assert outputs != ""
 
 
-def test_good_input_webverify_output_promela():
+def test_given_good_input_when_webverify_then_success():
     # given
     bpmn = ""
     with open("./test/resources/simple_example/test_bpmn.bpmn", "r") as bpmn_file:
@@ -143,12 +140,9 @@ def test_good_input_webverify_output_promela():
 
     # then
     assert is_successful(result)
-    outputs = result.unwrap()
-    assert outputs is not None
-    assert outputs != ""
 
 
-def test_bad_input_webverify_output_error():
+def test_given_bad_input_when_webverify_then_failure():
     # given
     bpmn = ""
     with open("./test/resources/simple_example/test_bpmn.bpmn", "r") as bpmn_file:

--- a/test/visitors/bpmnchecks/test_bpmn_connectivity_visitor.py
+++ b/test/visitors/bpmnchecks/test_bpmn_connectivity_visitor.py
@@ -1,4 +1,7 @@
 # type: ignore
+import pytest
+
+from bpmncwpverify.core.bpmn import Node
 from bpmncwpverify.core.error import (
     BpmnMsgEndEventError,
     BpmnMsgGatewayError,
@@ -6,8 +9,6 @@ from bpmncwpverify.core.error import (
     BpmnMsgTargetError,
 )
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidations import ValidateMsgsVisitor
-import pytest
-from bpmncwpverify.core.bpmn import Node
 
 
 def test_ensure_in_and_out_messages(mocker):

--- a/test/visitors/bpmnchecks/test_bpmnvalidate.py
+++ b/test/visitors/bpmnchecks/test_bpmnvalidate.py
@@ -1,5 +1,6 @@
 # type: ignore
 import pytest
+
 from bpmncwpverify.core.error import BpmnMsgFlowSamePoolError
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidate import validate_bpmn
 

--- a/test/visitors/bpmnchecks/test_bpmnvalidations.py
+++ b/test/visitors/bpmnchecks/test_bpmnvalidations.py
@@ -1,17 +1,6 @@
 # type: ignore
-from bpmncwpverify.core.error import (
-    BpmnFlowIncomingError,
-    BpmnFlowOutgoingError,
-    BpmnGraphConnError,
-    BpmnMissingEventsError,
-    BpmnMsgStartEventError,
-    BpmnSeqFlowEndEventError,
-    BpmnFlowStartEventError,
-    BpmnSeqFlowNoExprError,
-    BpmnTaskFlowError,
-    BpmnInvalidIdError,
-)
 import pytest
+
 from bpmncwpverify.core.bpmn import (
     EndEvent,
     ExclusiveGatewayNode,
@@ -19,14 +8,26 @@ from bpmncwpverify.core.bpmn import (
     StartEvent,
     Task,
 )
+from bpmncwpverify.core.error import (
+    BpmnFlowIncomingError,
+    BpmnFlowOutgoingError,
+    BpmnFlowStartEventError,
+    BpmnGraphConnError,
+    BpmnInvalidIdError,
+    BpmnMissingEventsError,
+    BpmnMsgStartEventError,
+    BpmnSeqFlowEndEventError,
+    BpmnSeqFlowNoExprError,
+    BpmnTaskFlowError,
+)
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidations import (
     ProcessConnectivityVisitor,
     ValidateBpmnIncomingFlows,
     ValidateBpmnOutgoingFlows,
+    ValidateIdVisitor,
+    ValidateSeqFlowVisitor,
     ValidateStartEventFlows,
     validate_start_end_events,
-    ValidateSeqFlowVisitor,
-    ValidateIdVisitor,
 )
 
 

--- a/test/visitors/test_bpmn_promela_visitor.py
+++ b/test/visitors/test_bpmn_promela_visitor.py
@@ -1,14 +1,14 @@
+import pytest
+
 from bpmncwpverify.core.bpmn import IntermediateEvent, ParallelGatewayNode, Task
+from bpmncwpverify.util.stringmanager import IndentAction, StringManager
 from bpmncwpverify.visitors.bpmn_promela_visitor import (
-    PromelaGenVisitor,
     NL_NONE,
     NL_SINGLE,
     Context,
+    PromelaGenVisitor,
     TokenPositions,
 )
-from bpmncwpverify.util.stringmanager import StringManager, IndentAction
-
-import pytest
 
 
 @pytest.fixture

--- a/test/visitors/test_cwp_connectivity_visitor.py
+++ b/test/visitors/test_cwp_connectivity_visitor.py
@@ -1,8 +1,9 @@
 # type: ignore
-from bpmncwpverify.visitors.cwp_connectivity_visitor import CwpConnectivityVisitor
-from bpmncwpverify.core.cwp import Cwp, CwpState, CwpEdge
-from bpmncwpverify.core.error import CwpGraphConnError
 import pytest
+
+from bpmncwpverify.core.cwp import Cwp, CwpEdge, CwpState
+from bpmncwpverify.core.error import CwpGraphConnError
+from bpmncwpverify.visitors.cwp_connectivity_visitor import CwpConnectivityVisitor
 
 
 @pytest.fixture

--- a/test/visitors/test_cwppromelavisitor.py
+++ b/test/visitors/test_cwppromelavisitor.py
@@ -1,14 +1,14 @@
-from bpmncwpverify.visitors.cwppromelavisitor import (
-    CwpPromelaVisitor,
-    START_STR,
-    END_STR,
-)
 import pytest
 
 from bpmncwpverify.util.stringmanager import (
-    NL_SINGLE,
     NL_DOUBLE,
+    NL_SINGLE,
     IndentAction,
+)
+from bpmncwpverify.visitors.cwppromelavisitor import (
+    END_STR,
+    START_STR,
+    CwpPromelaVisitor,
 )
 
 


### PR DESCRIPTION
* Reorder imports due to renaming
* Add errors for XML parse failure
* Revise `file.py` to be `IOResult[*,Error]`

Closes #72, #129, #131, #146, #262, #268