### PR TITLE
Refactor PromelaBuider to take object instances

### DIFF
--- a/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
@@ -15,15 +15,6 @@ from bpmncwpverify.core.bpmn import (
 from bpmncwpverify.core.error import Error
 from bpmncwpverify.core.state import State
 from bpmncwpverify.visitors.bpmn_graph_visitor import GraphVizVisitor
-from bpmncwpverify.visitors.bpmn_promela_visitor import PromelaGenVisitor
-
-
-def generate_promela(bpmn: Bpmn) -> str:
-    promela_visitor = PromelaGenVisitor()
-
-    bpmn.accept(promela_visitor)
-
-    return str(promela_visitor)
 
 
 def from_xml(root: Element, state: State) -> Result["Bpmn", Error]:

--- a/src/bpmncwpverify/core/accessmethods/cwpmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/cwpmethods.py
@@ -14,7 +14,6 @@ from bpmncwpverify.core.error import (
 from bpmncwpverify.core.expr import ExpressionListener
 from bpmncwpverify.core.state import State
 from bpmncwpverify.visitors.cwp_graph_visitor import CwpGraphVizVisitor
-from bpmncwpverify.visitors.cwp_promela_visitor import CwpPromelaVisitor
 
 
 class CwpXmlParser:
@@ -102,11 +101,3 @@ def generate_graph_viz(cwp: Cwp) -> None:
     cwp.accept(graph_viz_visitor)
 
     graph_viz_visitor.dot.render("graphs/cwp_graph.gv", format="png")  # type: ignore[unused-ignore]
-
-
-def generate_cwp_promela(cwp: Cwp, state: State) -> str:
-    ltl_visitor = CwpPromelaVisitor()
-
-    cwp.accept(ltl_visitor)
-
-    return str(ltl_visitor)

--- a/src/bpmncwpverify/core/state.py
+++ b/src/bpmncwpverify/core/state.py
@@ -764,7 +764,7 @@ class State:
         return result
 
     @staticmethod
-    def generate_promela(state: "State") -> Result[str, Error]:
+    def generate_promela(state: "State") -> str:
         str_builder: List[str] = []
         str_builder.append("//**********VARIABLE DECLARATION************//")
         for const_decl in state._consts:
@@ -788,7 +788,7 @@ class State:
                 str_builder.append(
                     f"{var_decl.type_} old_{var_decl.id} = {var_decl.id}"
                 )
-        return Success("\n".join(str_builder) + "\n\n")
+        return "\n".join(str_builder) + "\n\n"
 
     def _build_id_2_type_enum(self, enum_decl: EnumDecl) -> Result["State", Error]:
         """

--- a/src/bpmncwpverify/util/file.py
+++ b/src/bpmncwpverify/util/file.py
@@ -66,10 +66,6 @@ def read_file_as_string(path: str) -> IOResult[str, Error]:
     return _read_file_contents(path)
 
 
-def read_file_as_xml(path: str) -> IOResult[Element, Error]:
-    return _read_file_contents(path).bind(element_tree_from_string)  # pyright: ignore[reportUnknownMemberType]
-
-
 def write_file_contents(contents: str, path: str) -> IOResult[None, Error]:
     result: IOResultE[None] = flow(
         path,

--- a/test/builder/test_promela_builder.py
+++ b/test/builder/test_promela_builder.py
@@ -1,17 +1,25 @@
 # type: ignore
-from bpmncwpverify.builder.promela_builder import PromelaBuilder
+from bpmncwpverify.builder.promela_builder import (
+    _generate_logger,
+    _get_variable_names,
+)
 from bpmncwpverify.util.stringmanager import NL_SINGLE, IndentAction
 
 
 def test_logger_generator(mocker):
-    mocker.patch.object(
-        PromelaBuilder, "variable_name_extractor", return_value=["test_string"]
+    # mocker.patch.object(
+    #     PromelaBuilder, "variable_name_extractor", return_value=["test_string"]
+    # )
+
+    mocker.patch(
+        "bpmncwpverify.builder.promela_builder._get_variable_names",
+        return_value=["test_string"],
     )
+
     mock_write_str = mocker.patch(
         "bpmncwpverify.builder.promela_builder.StringManager.write_str"
     )
 
-    sb = PromelaBuilder()
     state = mocker.Mock()
 
     mock_val1 = mocker.Mock()
@@ -20,7 +28,7 @@ def test_logger_generator(mocker):
     mock_val2.name = "test_val2"
 
     cwp = mocker.Mock(states={"_0": mock_val1, "_1": mock_val2})
-    sb.logger_generator(state, cwp)
+    _generate_logger(state, cwp)
 
     calls = [
         mocker.call("inline stateLogger(){", NL_SINGLE, IndentAction.INC),
@@ -54,8 +62,6 @@ def test_variable_name_extractor(mocker):
     state = mocker.Mock()
     state.vars = vars
 
-    sb = PromelaBuilder()
-
-    result = sb.variable_name_extractor(state)
+    result = _get_variable_names(state)
 
     assert result == [1, 2]

--- a/test/core/test_state.py
+++ b/test/core/test_state.py
@@ -307,4 +307,4 @@ def test_generate_promela(mocker):
         "mtype:enum_id var2_id = init_val\n"
         "mtype:enum_id old_var2_id = var2_id\n\n"
     )
-    assert result.unwrap() == expected
+    assert result == expected

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,10 +5,9 @@ import sys
 import pytest
 from returns.functions import not_
 from returns.pipeline import is_successful
-from returns.result import Success
 from returns.unsafe import unsafe_perform_io
 
-from bpmncwpverify.cli import verify_with_spin, web_verify
+from bpmncwpverify.cli import cli_verify, web_verify
 from bpmncwpverify.core.error import Error, FileReadFileError, StateSyntaxError
 from bpmncwpverify.core.state import State
 
@@ -34,7 +33,7 @@ def test_givin_bad_state_file_path_when_verify_then_io_error(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
+    result = cli_verify(test_args[1], test_args[2], test_args[3])
 
     # then
     assert not_(is_successful)(result)
@@ -53,7 +52,7 @@ def test_givin_bad_cwp_file_path_when_verify_then_io_error(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
+    result = cli_verify(test_args[1], test_args[2], test_args[3])
 
     # then
     assert not_(is_successful)(result)
@@ -72,7 +71,7 @@ def test_givin_bad_bpmn_file_path_when_verify_then_io_error(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
+    result = cli_verify(test_args[1], test_args[2], test_args[3])
 
     # then
     assert not_(is_successful)(result)
@@ -91,7 +90,7 @@ def test_givin_bad_state_file_when_verify_then_state_errror(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
+    result = cli_verify(test_args[1], test_args[2], test_args[3])
 
     # then
     assert not_(is_successful)(result)
@@ -111,7 +110,7 @@ def test_givin_good_files_when_verify_then_success(capsys):
     sys.argv = test_args
 
     # when
-    result = verify_with_spin(test_args[1], test_args[2], test_args[3])
+    result = cli_verify(test_args[1], test_args[2], test_args[3])
 
     # then
     assert is_successful(result)
@@ -207,8 +206,7 @@ def test_generate_promela_with_full_state(mocker, mock_state):
         "int old_counter = counter\n\n"
     )
 
-    assert isinstance(result, Success)
-    assert result.unwrap() == expected_output
+    assert result == expected_output
 
 
 def test_generate_promela_with_only_constants(mocker, mock_state):
@@ -226,8 +224,7 @@ def test_generate_promela_with_only_constants(mocker, mock_state):
         "//**********VARIABLE DECLARATION************//\n#define BUFFER_SIZE 256\n\n"
     )
 
-    assert isinstance(result, Success)
-    assert result.unwrap() == expected_output
+    assert result == expected_output
 
 
 def test_generate_promela_with_only_enums(mocker, mock_state):
@@ -249,8 +246,7 @@ def test_generate_promela_with_only_enums(mocker, mock_state):
         "mtype:TestEnum = {IDLE RUNNING}\n\n"
     )
 
-    assert isinstance(result, Success)
-    assert result.unwrap() == expected_output
+    assert result == expected_output
 
 
 def test_generate_promela_with_empty_state(mock_state):
@@ -260,5 +256,4 @@ def test_generate_promela_with_empty_state(mock_state):
 
     expected_output = "//**********VARIABLE DECLARATION************//\n\n"
 
-    assert isinstance(result, Success)
-    assert result.unwrap() == expected_output
+    assert result == expected_output


### PR DESCRIPTION
* `PromelaBuilder` not takes `State`, `Cwp`, and `Bpmn`
* All static methods removed in `PromelaBuilder`
* CLI refactored to not repeat itself
* Use the `NotInitializedError`

Closes #277, #284, #285