### PR TITLE
Refacter state.py to be idiomatic with returns

### DIFF
--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -497,6 +497,14 @@ class StateSyntaxError(Error):
         super().__init__()
 
 
+class StateAntlrWalkerError(Error):
+    __slots__ = "msg"
+
+    def __init__(self, msg: str) -> None:
+        self.msg = msg
+        super().__init__()
+
+
 class SubProcessRunError(Error):
     __slots__ = "process_name"
 
@@ -680,6 +688,8 @@ def get_error_message(error: Error) -> str:
                     f"{idx + 1}: On line {map['line_number']} in the file '{map['file_path']}': {map['error_msg']}"
                 )
             return "\n".join(errors)
+        case StateAntlrWalkerError(msg=msg):
+            return "STATE ERROR: {}".format(msg)
         case StateInitNotInValues(id=id, line=line, column=column, values=values):
             location: str = " "
             if line != Nothing and column != Nothing:

--- a/test/core/test_error.py
+++ b/test/core/test_error.py
@@ -53,6 +53,7 @@ from bpmncwpverify.core.error import (
     SpinCoverageError,
     SpinInvalidEndStateError,
     SpinSyntaxError,
+    StateAntlrWalkerError,
     StateInitNotInValues,
     StateMultipleDefinitionError,
     StateSyntaxError,
@@ -265,6 +266,10 @@ test_inputs: list[tuple[Error, str]] = [
         "Syntax Error in generated promela:\n1 error(s) occurred:\n1: On line 1 in the file 'test/file/path': test_msg",
     ),
     (
+        StateAntlrWalkerError("error"),
+        "STATE ERROR: error",
+    ),
+    (
         StateInitNotInValues("a", Some(0), Some(1), {"b", "c"}),
         "STATE ERROR: init value 'a' at line 0:1 not in allowed values ['b', 'c']",
     ),
@@ -341,6 +346,7 @@ test_ids: list[str] = [
     "SpinCoverageError",
     "SpinInvalidEndStateError",
     "SpinSyntaxError",
+    "StateAntlrWalkerError",
     "StateInitNotInValues",
     "StateInitNotInValuesLineCol",
     "StateMultipleDefinitionError",


### PR DESCRIPTION
* Remove `@static` in flows
* Make member methods take the `self` instance when they side-effect
* Mutating member methods return `None`
* Prefer `bind` and `map` to `flow`
* Remove needless `unwrap` and `failure` calls

Closes #288