### PR TITLE
Adds color support to the devcontainer

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -26,10 +26,14 @@ npm install -g pyright
 pre-commit install
 
 # --- devcontainer niceties (dircolors, aliases) ---
+# Append color support to ~/.bashrc so it persists in interactive shells.
+# post-create.sh runs in its own subshell, so aliases and exports set here
+# would not survive into new terminal sessions without writing them to a
+# shell profile.
+cat >> ~/.bashrc << 'EOF'
 
-# Mac-ish LS_COLORS (closer to BSD/macOS vibe)
+# Color support (added by devcontainer post-create)
 export LS_COLORS='di=34:ln=36:so=35:pi=33:ex=32:bd=33;01:cd=33;01:su=31;01:sg=31;01:tw=34;01:ow=34;01:'
-
 alias ls='ls --color=auto'
 alias ll='ls -alhF --color=auto'
 alias la='ls -A'
@@ -38,3 +42,4 @@ alias diff='diff --color=auto'
 alias ip='ip -color=auto'
 export LESS='-R'
 export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+EOF

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -24,3 +24,17 @@ npm install -g pyright
 
 # Install pre-commit
 pre-commit install
+
+# --- devcontainer niceties (dircolors, aliases) ---
+
+# Mac-ish LS_COLORS (closer to BSD/macOS vibe)
+export LS_COLORS='di=34:ln=36:so=35:pi=33:ex=32:bd=33;01:cd=33;01:su=31;01:sg=31;01:tw=34;01:ow=34;01:'
+
+alias ls='ls --color=auto'
+alias ll='ls -alhF --color=auto'
+alias la='ls -A'
+alias grep='grep --color=auto'
+alias diff='diff --color=auto'
+alias ip='ip -color=auto'
+export LESS='-R'
+export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'


### PR DESCRIPTION
The devcontainer is built on Amazon Linux 2023, a minimal container image that ships with no color configuration out of the box. Developers opening a terminal inside the container are met with monochrome output for ls, grep, diff, and other everyday commands -- a noticeable step down from the color-rich terminals most are used to on macOS or desktop Linux. This makes it harder to scan directory listings, spot search matches, and read compiler diagnostics at a glance.

This change appends aliases and environment variables to ~/.bashrc during container creation so that color support persists across all interactive terminal sessions. Writing to the shell profile is necessary because post-create.sh runs in its own subshell -- any aliases or exports set directly in the script would be lost as soon as it exits. This is the standard Linux approach. 

#### What's added:
```bash
Aliases (ls, ll, la, grep, diff, ip) using --color=auto, which emits ANSI color codes only when stdout is an interactive terminal so piped and redirected output stays clean.
LS_COLORS -- defines which colors map to which file types (directories, symlinks, executables, etc.).
LESS='-R' -- tells less to pass through ANSI escape codes so colored output piped to a pager still renders correctly.
GCC_COLORS -- enables colored diagnostics in GCC/G++ compiler output.
```

Resolves #296