### PR TITLE
issue #298 fix

### DIFF
--- a/src/bpmncwpverify/core/accessmethods/cwpmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/cwpmethods.py
@@ -85,11 +85,10 @@ class CwpXmlParser:
             expr_lstnr = ExpressionListener(state)
             parser._add_states(builder, states)
             parser._add_edges(builder, edges)
+            parser._check_expressions(builder, all_items, expr_lstnr, state)
         except Exception as e:
             assert e.args, "Error does not have enough arguments"
             return Failure(e.args[0])
-
-        parser._check_expressions(builder, all_items, expr_lstnr, state)
 
         result: Result["Cwp", Error] = builder.build()
         return result


### PR DESCRIPTION
Fixes #298 

The issue seemed to be an error (Exception(result.failure())) that wasn't caught and processed properly. In looking at the XML file and state.txt file we see that the error comes from a variable "dangerground" not being defined. When we went to "/workspaces/bpmn_cwp_verify/src/bpmncwpverify/builder/cwp_builder.py" we see where it throws an error but doesn't catch it.

The first thought we had was that we need to catch it somehow and record what it was getting stuck on. We looked into how try and accept statements worked so we could catch the error message softly and return some kind of esasier to proccess message. Then we realized that the code above was already a massive try and accept statement that was doing basically what we wanted to do so we dragged the line that was throwing the error into that and it caught it with a more clear error message.