### PR TITLE
Show errors more clearly in web UI

### DIFF
--- a/src/bpmncwpverify/web/mainPage.html
+++ b/src/bpmncwpverify/web/mainPage.html
@@ -47,6 +47,7 @@
       const lambdaUrl = 'https://iatjgvm4gt75bw4qwbz7l3bihq0irdns.lambda-url.us-east-1.on.aws/';
 
       statusContainer.textContent = 'Processing...';
+      populateSpinReport('');
 
       const fileToString = (file) => {
         return new Promise((resolve, reject) => {
@@ -73,7 +74,8 @@
         });
 
         if (!response.ok) {
-          throw new Error(`HTTP error! Status: ${response.status}`);
+          const body = await response.json();
+          throw new Error(`HTTP error! Status: ${response.status}—${body.error}`);
         }
 
         const result = await response.json();


### PR DESCRIPTION
Display the error message that the lambda returns. For example, when verifying the boundary events example, the UI now displays "Error: HTTP error! Status: 400—Verification failed" rather than just showing a 400 error.

Clear output from previous verification while waiting for a response to a request.