### PR TITLE
Move style checks from mypy to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,7 @@ repos:
         language: system
         types: [python]
         args: ["--config-file=pyproject.toml"]
+        require_serial: true
         exclude: ^(test/|src/bpmncwpverify/antlr/)
 -   repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dev = [
   "pytest>=8.2.0",
   "pytest-mock",
   "ruff>=0.4.4",
-  "returns[compatible-mypy]",
+  "returns==0.27.0",
+  "mypy==1.20.2",
   "pre-commit",
   "nitpick",
   "antlr4-tools",
@@ -37,7 +38,7 @@ dev = [
   ]
 
 [tool.ruff]
-lint.extend-select = ["I"]
+lint.extend-select = ["I", "UP"]
 target-version = "py312"
 
 [tool.nitpick]
@@ -54,8 +55,6 @@ follow_imports = "silent"
 ignore_missing_imports = true
 strict = true
 warn_unreachable = true
-force_uppercase_builtins = true
-force_union_syntax = true
 disallow_subclassing_any = true
 
 [tool.pytest.ini_options]

--- a/src/bpmncwpverify/builder/process_builder.py
+++ b/src/bpmncwpverify/builder/process_builder.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from returns.functions import not_
 from returns.pipeline import is_successful
 from returns.result import Failure, Result, Success
@@ -18,7 +16,7 @@ class ProcessBuilder:
         self._process = Process(id, name)
         self._state = state
 
-    def with_element(self, element: Union[SequenceFlow, Node]) -> "ProcessBuilder":
+    def with_element(self, element: SequenceFlow | Node) -> "ProcessBuilder":
         self._process[element.id] = element
         return self
 
@@ -46,7 +44,7 @@ class ProcessBuilder:
         flow_id: str,
         source_ref: str,
         target_ref: str,
-        expression: Union[str, None],
+        expression: str | None,
     ) -> Result["ProcessBuilder", Error]:
         flow = self._process[flow_id]
         source_node = self._process[source_ref]

--- a/src/bpmncwpverify/core/accessmethods/cwpmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/cwpmethods.py
@@ -1,4 +1,3 @@
-from typing import List
 from xml.etree.ElementTree import Element
 
 from returns.result import Failure, Result
@@ -17,7 +16,7 @@ from bpmncwpverify.visitors.cwp_graph_visitor import CwpGraphVizVisitor
 
 
 class CwpXmlParser:
-    def _get_mx_cells(self, root: Element) -> List[Element]:
+    def _get_mx_cells(self, root: Element) -> list[Element]:
         if (diagram := root.find("diagram")) is None:
             raise Exception(CwpFileStructureError("diagram"))
         if (mx_graph_model := diagram.find("mxGraphModel")) is None:
@@ -28,23 +27,23 @@ class CwpXmlParser:
             raise Exception(CwpFileStructureError("mxCell"))
         return mx_cells
 
-    def _get_all_items(self, mx_cells: List[Element]) -> List[Element]:
+    def _get_all_items(self, mx_cells: list[Element]) -> list[Element]:
         return [itm for itm in mx_cells]
 
-    def _get_edges(self, mx_cells: List[Element]) -> List[Element]:
+    def _get_edges(self, mx_cells: list[Element]) -> list[Element]:
         return [itm for itm in mx_cells if itm.get("edge")]
 
-    def _get_states(self, mx_cells: List[Element]) -> List[Element]:
+    def _get_states(self, mx_cells: list[Element]) -> list[Element]:
         return [itm for itm in mx_cells if itm.get("vertex")]
 
-    def _add_states(self, builder: CwpBuilder, states: List[Element]) -> None:
+    def _add_states(self, builder: CwpBuilder, states: list[Element]) -> None:
         for element in states:
             style = element.get("style")
             if style and "edgeLabel" not in style:
                 state = CwpState.from_xml(element)
                 builder = builder.with_state(state)
 
-    def _add_edges(self, builder: CwpBuilder, edges: List[Element]) -> None:
+    def _add_edges(self, builder: CwpBuilder, edges: list[Element]) -> None:
         for element in edges:
             source_ref = element.get("source")
             target_ref = element.get("target")
@@ -57,7 +56,7 @@ class CwpXmlParser:
     def _check_expressions(
         self,
         builder: CwpBuilder,
-        all_items: List[Element],
+        all_items: list[Element],
         expr_lstnr: ExpressionListener,
         state: State,
     ) -> None:
@@ -90,7 +89,7 @@ class CwpXmlParser:
             assert e.args, "Error does not have enough arguments"
             return Failure(e.args[0])
 
-        result: Result["Cwp", Error] = builder.build()
+        result: Result[Cwp, Error] = builder.build()
         return result
 
 

--- a/src/bpmncwpverify/core/accessmethods/processmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/processmethods.py
@@ -1,4 +1,3 @@
-from typing import Union
 from xml.etree.ElementTree import Element
 
 from returns.functions import not_
@@ -30,13 +29,13 @@ def from_xml(element: Element, state: State) -> Result["Process", Error]:
         result = get_element_type(tag)
         if not_(is_successful)(result):
             return Failure(result.failure())
-        element_type: Union[type[SequenceFlow], type[Node]] = result.unwrap()
+        element_type: type[SequenceFlow] | type[Node] = result.unwrap()
 
         class_object = element_type.from_xml(sub_element)
         builder = builder.with_element(class_object)
 
     for seq_flow in element.findall("bpmn:sequenceFlow", BPMN_XML_NAMESPACE):
-        result_builder: Result["ProcessBuilder", Error] = builder.with_process_flow(
+        result_builder: Result[ProcessBuilder, Error] = builder.with_process_flow(
             seq_flow.attrib["id"],
             seq_flow.attrib["sourceRef"],
             seq_flow.attrib["targetRef"],

--- a/src/bpmncwpverify/core/bpmn.py
+++ b/src/bpmncwpverify/core/bpmn.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar
 from xml.etree.ElementTree import Element
 
 from returns.result import Failure, Result, Success
@@ -33,7 +33,7 @@ class BpmnElement:
         self.name = name
 
     @classmethod
-    def from_xml(cls: Type[T], element: Element) -> T:
+    def from_xml(cls: type[T], element: Element) -> T:
         id = element.attrib.get("id")
         if not id:
             raise Exception("Id cannot be None")
@@ -69,10 +69,10 @@ class Node(BpmnElement):
         name: str,
     ) -> None:
         super().__init__(id, name)
-        self.out_flows: List[SequenceFlow] = []
-        self.in_flows: List[SequenceFlow] = []
-        self.in_msgs: List[MessageFlow] = []
-        self.out_msgs: List[MessageFlow] = []
+        self.out_flows: list[SequenceFlow] = []
+        self.in_flows: list[SequenceFlow] = []
+        self.in_msgs: list[MessageFlow] = []
+        self.out_msgs: list[MessageFlow] = []
 
     def add_out_flow(self, flow: "SequenceFlow") -> None:
         """
@@ -269,7 +269,7 @@ class Task(Node):
     def __init__(self, id: str, name: str, behavior: str) -> None:
         super().__init__(id, name)
         self.behavior = behavior
-        self.msg_boundary_events: List[Task.BoundaryEvent] = []
+        self.msg_boundary_events: list[Task.BoundaryEvent] = []
 
     def add_boundary_event(self, event: BoundaryEvent) -> None:
         self.msg_boundary_events.append(event)
@@ -398,9 +398,9 @@ class Process(BpmnElement):
         Initialize Process object
         """
         super().__init__(id, name)
-        self._flows: Dict[str, SequenceFlow] = {}
-        self._elements: Dict[str, Node] = {}
-        self._start_states: Dict[str, StartEvent] = {}
+        self._flows: dict[str, SequenceFlow] = {}
+        self._elements: dict[str, Node] = {}
+        self._start_states: dict[str, StartEvent] = {}
 
     def __setitem__(self, key: str, item: BpmnElement) -> None:
         """
@@ -417,7 +417,7 @@ class Process(BpmnElement):
         elif isinstance(item, Node):
             self._elements[key] = item
 
-    def __getitem__(self, key: str) -> Union[Node, Flow]:
+    def __getitem__(self, key: str) -> Node | Flow:
         """
         Retrieve item stored in business process
 
@@ -434,19 +434,19 @@ class Process(BpmnElement):
             BpmnStructureError(key, "Key not found in any of the processe's elements")
         )
 
-    def get_flows(self) -> Dict[str, SequenceFlow]:
+    def get_flows(self) -> dict[str, SequenceFlow]:
         """
         Return flows of business model
         """
         return self._flows
 
-    def all_items(self) -> Dict[str, Node]:
+    def all_items(self) -> dict[str, Node]:
         """
         Return all items of business model
         """
         return self._elements | self._start_states
 
-    def get_start_states(self) -> Dict[str, StartEvent]:
+    def get_start_states(self) -> dict[str, StartEvent]:
         """
         Return start states of business model
         """
@@ -459,14 +459,14 @@ class Process(BpmnElement):
         visitor.end_visit_process(self)
 
 
-def get_element_type(tag: str) -> Result[Union[type[SequenceFlow], type[Node]], Error]:
+def get_element_type(tag: str) -> Result[type[SequenceFlow] | type[Node], Error]:
     """
     Maps tag name to its respective builder function
 
     Args:
         tag (str): String representation of builder function
     """
-    mapping: Dict[str, Union[type[SequenceFlow], type[Node]]] = {
+    mapping: dict[str, type[SequenceFlow] | type[Node]] = {
         "task": Task,
         "startEvent": StartEvent,
         "endEvent": EndEvent,
@@ -498,9 +498,9 @@ class Bpmn:
         """
         Initialize Bpmn object
         """
-        self.processes: Dict[str, Process] = {}
-        self.id_to_element: Dict[str, BpmnElement] = {}  # Maps ids to elements
-        self.inter_process_msgs: Dict[str, MessageFlow] = {}
+        self.processes: dict[str, Process] = {}
+        self.id_to_element: dict[str, BpmnElement] = {}  # Maps ids to elements
+        self.inter_process_msgs: dict[str, MessageFlow] = {}
 
     def store_element(self, element: BpmnElement) -> None:
         """

--- a/src/bpmncwpverify/core/counterexample.py
+++ b/src/bpmncwpverify/core/counterexample.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-from typing import Type
 
 from bpmncwpverify.core.error import Error
 from bpmncwpverify.util.stringmanager import NL_SINGLE, StringManager
@@ -22,7 +21,7 @@ class CounterExample:
     Class to represent a counterexample.
     """
 
-    def __init__(self, trace_steps: list[ErrorTrace], error: Type["Error"]):
+    def __init__(self, trace_steps: list[ErrorTrace], error: type["Error"]):
         self.trace_steps = trace_steps
         self.error = error.__name__
 
@@ -45,7 +44,7 @@ class CounterExample:
 
     @staticmethod
     def generate_counterexample(
-        file_path: str, error: Type["Error"]
+        file_path: str, error: type["Error"]
     ) -> "CounterExample":
         """
         Generate a counterexample from the given file path and error.

--- a/src/bpmncwpverify/core/cwp.py
+++ b/src/bpmncwpverify/core/cwp.py
@@ -1,14 +1,13 @@
 import re
-from typing import Dict, List, Optional
 from xml.etree.ElementTree import Element
 
 
 class Cwp:
     def __init__(self) -> None:
-        self.states: Dict[str, CwpState] = {}
-        self.edges: Dict[str, CwpEdge] = {}
+        self.states: dict[str, CwpState] = {}
+        self.edges: dict[str, CwpEdge] = {}
         self.start_state: CwpState
-        self.end_states: List[CwpState] = []
+        self.end_states: list[CwpState] = []
 
     def accept(self, visitor: "CwpVisitor") -> None:
         result = visitor.visit_cwp(self)
@@ -21,8 +20,8 @@ class CwpState:
     def __init__(self, id: str, name: str) -> None:
         self.id = id
         self.name = name
-        self.out_edges: List[CwpEdge] = []
-        self.in_edges: List[CwpEdge] = []
+        self.out_edges: list[CwpEdge] = []
+        self.in_edges: list[CwpEdge] = []
 
     def accept(self, visitor: "CwpVisitor") -> None:
         result = visitor.visit_state(self)
@@ -55,7 +54,7 @@ class CwpEdge:
         )
         self.parent_id: str
 
-        self.source: Optional[CwpState] = None
+        self.source: CwpState | None = None
         self.dest: CwpState
         self.is_leaf = False
 

--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -223,7 +223,7 @@ class CwpGraphConnError(Error):
 class CwpMultStartStateError(Error):
     __slots__ = ["start_states"]
 
-    def __init__(self, start_states: typing.List[str]) -> None:
+    def __init__(self, start_states: list[str]) -> None:
         super().__init__()
         self.start_states = start_states
 
@@ -431,7 +431,7 @@ class SpinAssertionError(CounterExampleError):
     def __init__(
         self,
         counter_example: str,
-        list_of_error_maps: typing.List[typing.Dict[str, str]],
+        list_of_error_maps: list[dict[str, str]],
     ):
         super().__init__(counter_example)
         self.list_of_error_maps = list_of_error_maps
@@ -441,7 +441,7 @@ class SpinCoverageError(CounterExampleError):
     __slots__ = ["coverage_errors"]
 
     def __init__(
-        self, counter_example: str, coverage_errors: typing.List[typing.Dict[str, str]]
+        self, counter_example: str, coverage_errors: list[dict[str, str]]
     ) -> None:
         super().__init__(counter_example)
         self.coverage_errors = coverage_errors
@@ -453,7 +453,7 @@ class SpinInvalidEndStateError(CounterExampleError):
     def __init__(
         self,
         counter_example: str,
-        list_of_error_maps: typing.List[typing.Dict[str, str]],
+        list_of_error_maps: list[dict[str, str]],
     ):
         super().__init__(counter_example)
         self.list_of_error_maps = list_of_error_maps
@@ -465,7 +465,7 @@ class SpinSyntaxError(CounterExampleError):
     def __init__(
         self,
         counter_example: str,
-        list_of_error_maps: typing.List[typing.Dict[str, str]],
+        list_of_error_maps: list[dict[str, str]],
     ):
         super().__init__(counter_example)
         self.list_of_error_maps = list_of_error_maps
@@ -654,33 +654,23 @@ def get_error_message(error: Error) -> str:
         case CwpNoStartStateError():
             return "CWP ERROR: No start states found."
         case ExpressionComputationCompatabilityError(ltype=ltype, rtype=rtype):
-            return "EXPR ERROR: sometion of type '{}' cannot be computed with something of type '{}'".format(
-                rtype, ltype
-            )
+            return f"EXPR ERROR: sometion of type '{rtype}' cannot be computed with something of type '{ltype}'"
         case ExpressionNegatorError(_type=_type):
-            return "EXPR ERROR: sometiong of type '{}' cannot be used with a mathmatical negator".format(
-                _type
-            )
+            return f"EXPR ERROR: sometiong of type '{_type}' cannot be used with a mathmatical negator"
         case ExpressionParseError(exception_str=exception_str):
             return f"Error while parsing expression: {exception_str}"
         case ExpressionRelationCompatabilityError(ltype=ltype, rtype=rtype):
-            return "EXPR ERROR: sometion of type '{}' cannot be related with something of type '{}'".format(
-                rtype, ltype
-            )
+            return f"EXPR ERROR: sometion of type '{rtype}' cannot be related with something of type '{ltype}'"
         case ExpressionRelationalNotError(_type=_type):
-            return "EXPR ERROR: sometiong of type '{}' cannot be used with a relational not".format(
-                _type
-            )
+            return f"EXPR ERROR: sometiong of type '{_type}' cannot be used with a relational not"
         case ExpressionUnrecognizedID(_id=_id):
-            return "EXPR ERROR: '{}' is not recognized as a literal or something stored in the symbol table".format(
-                _id
-            )
+            return f"EXPR ERROR: '{_id}' is not recognized as a literal or something stored in the symbol table"
         case FileReadFileError(msg=msg):
-            return "FILE ERROR: '{}'".format(msg)
+            return f"FILE ERROR: '{msg}'"
         case FileWriteFileError(msg=msg):
-            return "FILE ERROR: '{}'".format(msg)
+            return f"FILE ERROR: '{msg}'"
         case FileXmlParseError(msg=msg):
-            return "FILE ERROR: '{}'".format(msg)
+            return f"FILE ERROR: '{msg}'"
         case FlowExpressionError(
             flow_id=flow_id, expression=expression, exception_str=exception_str
         ):
@@ -694,9 +684,9 @@ def get_error_message(error: Error) -> str:
         case MessageError(node_id=node_id, error_msg=error_msg):
             return f"Inter-process message error at node: {node_id}. {error_msg}"
         case NotImplementedError(function=function):
-            return "ERROR: not implemented '{}'".format(function)
+            return f"ERROR: not implemented '{function}'"
         case NotInitializedError(var_name=var_name):
-            return "ERROR: '{}' is not initialized".format(var_name)
+            return f"ERROR: '{var_name}' is not initialized"
         case RequestError(err=err):
             return (
                 f"ERROR: Unknown error occurred while sending request to lambda: {err}"
@@ -734,14 +724,12 @@ def get_error_message(error: Error) -> str:
                 )
             return "\n".join(errors)
         case StateAntlrWalkerError(msg=msg):
-            return "STATE ERROR: {}".format(msg)
+            return f"STATE ERROR: {msg}"
         case StateInitNotInValues(id=id, line=line, column=column, values=values):
             location: str = " "
             if line != Nothing and column != Nothing:
                 location = f" at line {line.unwrap()}:{column.unwrap()} "
-            return "STATE ERROR: init value '{}'{}not in allowed values {}".format(
-                id, location, sorted(values)
-            )
+            return f"STATE ERROR: init value '{id}'{location}not in allowed values {sorted(values)}"
         case StateMultipleDefinitionError(
             id=id,
             line=line,
@@ -757,19 +745,15 @@ def get_error_message(error: Error) -> str:
             if prev_line != Nothing and prev_column != Nothing:
                 location_second = f", previously defined at line {prev_line.unwrap()}:{prev_column.unwrap()}"
 
-            return "STATE ERROR: multiple definition of '{}'{}{}".format(
-                id, location_first, location_second
-            )
+            return f"STATE ERROR: multiple definition of '{id}'{location_first}{location_second}"
         case StateSyntaxError(msg=msg):
-            return "STATE SYNTAX ERROR: {}".format(msg)
+            return f"STATE SYNTAX ERROR: {msg}"
         case SubProcessRunError(process_name=process_name):
-            return "ERROR: failed to run '{}'".format(process_name)
+            return f"ERROR: failed to run '{process_name}'"
         case TypingAssignCompatabilityError(ltype=ltype, rtype=rtype):
-            return "TYPING ERROR: something of type '{}' cannot by assigned to something of type '{}'".format(
-                rtype, ltype
-            )
+            return f"TYPING ERROR: something of type '{rtype}' cannot by assigned to something of type '{ltype}'"
         case TypingNoTypeError(id=id):
-            return "TYPING ERROR: literal '{}' has an unknown type".format(id)
+            return f"TYPING ERROR: literal '{id}' has an unknown type"
 
         case _:
             raise builtins.NotImplementedError

--- a/src/bpmncwpverify/core/expr.py
+++ b/src/bpmncwpverify/core/expr.py
@@ -1,4 +1,4 @@
-from typing import Any, List, cast
+from typing import Any, cast
 
 from antlr4 import CommonTokenStream, InputStream, ParseTreeWalker
 from antlr4.error.ErrorListener import ConsoleErrorListener, ErrorListener
@@ -60,7 +60,7 @@ class ThrowingErrorListener(ErrorListener):  # type: ignore[misc]
             msg (str): Error message passed along by the recognizer
             e (Exception): Exception associated with error
         """
-        msg = "line {}:{} {}".format(line, column, msg)
+        msg = f"line {line}:{column} {msg}"
         raise ParseCancellationException(msg)
 
 
@@ -119,7 +119,7 @@ class ExpressionListener(ExprListener):
         """
         self.final_type: str
         self.state = state
-        self.type_stack: List[str] = []
+        self.type_stack: list[str] = []
 
     def check_arithmetic_types(self, left_type: str, right_type: str) -> None:
         """

--- a/src/bpmncwpverify/core/spin.py
+++ b/src/bpmncwpverify/core/spin.py
@@ -1,7 +1,6 @@
 import os
 import re
 import subprocess
-from typing import Dict, List
 
 from returns.io import IOFailure, IOResult, IOSuccess, impure_safe
 from returns.pipeline import flow
@@ -119,7 +118,7 @@ class SpinVerificationReportBuilder:
 
 
 class SpinOutputParser:
-    def _get_re_matches(self, regex: str, spin_msg: str) -> List[Dict[str, str]]:
+    def _get_re_matches(self, regex: str, spin_msg: str) -> list[dict[str, str]]:
         r = re.compile(regex)
 
         return [
@@ -191,7 +190,7 @@ class SpinOutputParser:
         # Find all relevant blocks (excluding never claims)
         matches = block_pattern.finditer(spin_msg)
 
-        detailed_errors: List[Dict[str, str]] = []
+        detailed_errors: list[dict[str, str]] = []
 
         for match in matches:
             proctype_name = (

--- a/src/bpmncwpverify/core/state.py
+++ b/src/bpmncwpverify/core/state.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, Protocol, cast
+from collections.abc import Iterable
+from typing import Any, Protocol, cast
 
 from antlr4 import CommonTokenStream, InputStream, ParseTreeWalker
 from antlr4.error.ErrorListener import ConsoleErrorListener, ErrorListener
@@ -127,7 +128,7 @@ class ThrowingErrorListener(ErrorListener):  # type: ignore[misc]
             msg (str): Error message passed along by the recognizer
             e (Exception): Exception associated with error
         """
-        msg = "line {}:{} {}".format(line, column, msg)
+        msg = f"line {line}:{column} {msg}"
         raise ParseCancellationException(msg)
 
 
@@ -420,7 +421,7 @@ class State:
             Initialize _Listener object
             """
             super().__init__()
-            self.state_builder: Result["StateBuilder", Error] = Success(StateBuilder())
+            self.state_builder: Result[StateBuilder, Error] = Success(StateBuilder())
 
         @staticmethod
         def _get_id(id_node: TerminalNodeImpl) -> str:
@@ -843,7 +844,7 @@ class State:
 
         state_def (str): String that contains varaible declarations
         """
-        result: Result["State", Error] = flow(
+        result: Result[State, Error] = flow(
             state_def,
             _get_parser,
             bind_result(_parse_state),

--- a/src/bpmncwpverify/core/typechecking.py
+++ b/src/bpmncwpverify/core/typechecking.py
@@ -1,4 +1,5 @@
-from typing import Callable, Final
+from collections.abc import Callable
+from typing import Final
 
 from returns.result import Failure, Result, Success
 

--- a/src/bpmncwpverify/util/file.py
+++ b/src/bpmncwpverify/util/file.py
@@ -1,4 +1,4 @@
-from typing import Optional, TextIO, cast
+from typing import TextIO, cast
 from xml.etree.ElementTree import Element
 
 from defusedxml import ElementTree
@@ -16,7 +16,7 @@ from bpmncwpverify.core.error import (
 
 def _close_file(
     file_obj: TextIO,
-    file_contents: ResultE[Optional[str]],
+    file_contents: ResultE[str | None],
 ) -> IOResultE[None]:
     return impure_safe(file_obj.close)()
 
@@ -35,7 +35,7 @@ def _read_file_contents(name: str) -> IOResult[str, Error]:
 
 
 def _open_file_for_reading(filename: str) -> TextIO:
-    return open(filename, "r")
+    return open(filename)
 
 
 def _open_file_for_writing(filename: str) -> TextIO:

--- a/src/bpmncwpverify/util/stringmanager.py
+++ b/src/bpmncwpverify/util/stringmanager.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Union
+from typing import Union
 
 NL_NONE = 0
 NL_SINGLE = 1
@@ -14,7 +14,7 @@ class IndentAction(Enum):
 
 class StringManager:
     def __init__(self) -> None:
-        self.contents: List[str] = []
+        self.contents: list[str] = []
         self.indent = 0
 
     def _tab(self) -> str:
@@ -52,7 +52,7 @@ class StringManager:
         if indent_action == IndentAction.DEC:
             self._dec_indent()
 
-        def needs_tab(idx: int, items: List[str]) -> bool:
+        def needs_tab(idx: int, items: list[str]) -> bool:
             """Helper function to determine if tabulation is necessary."""
             # Check if it's the first item and if the last content line ends with a newline
             if idx == 0:

--- a/src/bpmncwpverify/visitors/bpmn_graph_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_graph_visitor.py
@@ -24,7 +24,7 @@ def dot_edge(graph: graphviz.Digraph, src: str, dst: str, label: str) -> None:
 
 class GraphVizVisitor(BpmnVisitor):
     def __init__(self, process_number: int) -> None:
-        self.dot = graphviz.Digraph(comment="Process graph {}".format(process_number))
+        self.dot = graphviz.Digraph(comment=f"Process graph {process_number}")
 
     def visit_start_event(self, event: StartEvent) -> bool:
         dot_node(self.dot, event.id, event.name)

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -1,5 +1,3 @@
-from typing import List, Optional
-
 from bpmncwpverify.core.bpmn import (
     Bpmn,
     BpmnVisitor,
@@ -47,7 +45,7 @@ class Context:
         self._behavior_model = True
         self._behavior = ""
         self._end_event = False
-        self._boundary_events: List[Task.BoundaryEvent] = []
+        self._boundary_events: list[Task.BoundaryEvent] = []
 
     @property
     def has_option(self) -> bool:
@@ -100,11 +98,11 @@ class Context:
         self._end_event = new_val
 
     @property
-    def boundary_events(self) -> List[Task.BoundaryEvent]:
+    def boundary_events(self) -> list[Task.BoundaryEvent]:
         return self._boundary_events
 
     @boundary_events.setter
-    def boundary_events(self, new_val: List[Task.BoundaryEvent]) -> None:
+    def boundary_events(self, new_val: list[Task.BoundaryEvent]) -> None:
         assert isinstance(self._element, Task), (
             "Only allowed to set boundary_events on a task."
         )
@@ -127,8 +125,8 @@ class TokenPositions:
 
     def __init__(
         self,
-        seq_flows: Optional[List[str]] = None,
-        msg_flows: Optional[List[str]] = None,
+        seq_flows: list[str] | None = None,
+        msg_flows: list[str] | None = None,
         standalone: str = "",
     ) -> None:
         self.seq_flows = seq_flows if seq_flows is not None else []
@@ -145,14 +143,14 @@ class TokenPositions:
                 "Either sequence/message flows or a standalone position must be provided."
             )
 
-    def get_all_positions(self) -> List[str]:
+    def get_all_positions(self) -> list[str]:
         return (
             self.seq_flows + self.msg_flows
             if (self.seq_flows or self.msg_flows)
             else [self.standalone]
         )
 
-    def get_in_process_positions(self) -> List[str]:
+    def get_in_process_positions(self) -> list[str]:
         if self.seq_flows:
             return self.seq_flows
         elif self.standalone:
@@ -170,7 +168,7 @@ class PromelaGenVisitor(BpmnVisitor):
         self.promela = StringManager()
 
     def _generate_location_label(
-        self, element: Node, flow_or_message: Optional[Flow] = None
+        self, element: Node, flow_or_message: Flow | None = None
     ) -> str:
         """
         Should only be called from _get_consume_locations and _get_put_locations.
@@ -200,7 +198,7 @@ class PromelaGenVisitor(BpmnVisitor):
             ],
         )
 
-    def _get_expressions(self, ctx: Context) -> List[str]:
+    def _get_expressions(self, ctx: Context) -> list[str]:
         """
         Returns a list of the expressions that lie on the flows leaving a specific
         node. Example: ["x > 5"]
@@ -263,7 +261,7 @@ class PromelaGenVisitor(BpmnVisitor):
         sm.write_str("fi", NL_SINGLE)
         return sm
 
-    def _get_put_locations(self, element: Node) -> List[str]:
+    def _get_put_locations(self, element: Node) -> list[str]:
         """
         Returns a list of labels representing all outgoing flows from a node.
         Each label indicates the target node and the current node as the source.
@@ -289,14 +287,14 @@ class PromelaGenVisitor(BpmnVisitor):
 
         # Store the consume locations to avoid multiple calls.
         consume_locations: TokenPositions = self._get_consume_locations(ctx.element)
-        inner_process_positions: List[str] = (
+        inner_process_positions: list[str] = (
             consume_locations.get_in_process_positions()
         )
-        msg_positions: List[str] = consume_locations.msg_flows
+        msg_positions: list[str] = consume_locations.msg_flows
 
         if inner_process_positions:
             guard.write_str("(")
-            tokens: List[str] = [f"hasToken({pos})" for pos in inner_process_positions]
+            tokens: list[str] = [f"hasToken({pos})" for pos in inner_process_positions]
             if ctx.is_parallel:
                 guard.write_str(" && ".join(tokens))
             else:
@@ -305,7 +303,7 @@ class PromelaGenVisitor(BpmnVisitor):
 
         if msg_positions:
             guard.write_str(" && (" if inner_process_positions else "(")
-            tokens_msg: List[str] = [f"hasToken({pos})" for pos in msg_positions]
+            tokens_msg: list[str] = [f"hasToken({pos})" for pos in msg_positions]
             guard.write_str(" && ".join(tokens_msg))
             guard.write_str(")")
 

--- a/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidations.py
+++ b/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidations.py
@@ -1,5 +1,4 @@
 import re
-from typing import Set
 
 from returns.result import Failure, Result, Success
 
@@ -41,7 +40,7 @@ from bpmncwpverify.core.error import (
 
 class ProcessConnectivityVisitor(BpmnVisitor):
     def __init__(self) -> None:
-        self.visited: Set[BpmnElement] = set()
+        self.visited: set[BpmnElement] = set()
 
     def visit_start_event(self, event: StartEvent) -> bool:
         self.visited.add(event)
@@ -195,7 +194,7 @@ class ValidateStartEventFlows(BpmnVisitor):
 
 class SetFlowLeafs(BpmnVisitor):
     def __init__(self) -> None:
-        self.visited: Set[BpmnElement] = set()
+        self.visited: set[BpmnElement] = set()
 
     def visit_start_event(self, event: StartEvent) -> bool:
         self.visited.add(event)

--- a/src/bpmncwpverify/visitors/cwp_connectivity_visitor.py
+++ b/src/bpmncwpverify/visitors/cwp_connectivity_visitor.py
@@ -1,12 +1,10 @@
-from typing import Set
-
 from bpmncwpverify.core.cwp import Cwp, CwpEdge, CwpState, CwpVisitor
 from bpmncwpverify.core.error import CwpGraphConnError
 
 
 class CwpConnectivityVisitor(CwpVisitor):
     def __init__(self) -> None:
-        self.visited: Set[CwpState] = set()
+        self.visited: set[CwpState] = set()
 
     def visit_state(self, state: CwpState) -> bool:
         self.visited.add(state)

--- a/test/core/test_expr_parser.py
+++ b/test/core/test_expr_parser.py
@@ -1,5 +1,5 @@
 # type: ignore
-from typing import Iterable
+from collections.abc import Iterable
 
 import pytest
 from antlr4.error.ErrorStrategy import ParseCancellationException

--- a/test/core/test_state.py
+++ b/test/core/test_state.py
@@ -1,6 +1,6 @@
 # type: ignore
 import re
-from typing import Iterable
+from collections.abc import Iterable
 
 import pytest
 from antlr4.error.ErrorStrategy import ParseCancellationException
@@ -65,7 +65,7 @@ class Test_get_parser:
         try:
             tree = parser.state()
         except Exception as exception:
-            pytest.fail("ERROR: unexpected {}".format(exception))
+            pytest.fail(f"ERROR: unexpected {exception}")
 
         # then
         assert 0 == parser.getNumberOfSyntaxErrors()
@@ -87,7 +87,7 @@ class Test_parse_state:
         self, bad_parser: Result[StateParser, Error]
     ):
         # given
-        assert is_successful(bad_parser), "ERROR: unexpected {}".format(str(bad_parser))
+        assert is_successful(bad_parser), f"ERROR: unexpected {str(bad_parser)}"
 
         # when
         result = bad_parser.bind(_parse_state)
@@ -102,9 +102,7 @@ class Test_parse_state:
         self, good_parser: Result[StateParser, Error]
     ):
         # given
-        assert is_successful(good_parser), "ERROR: unexpected {}".format(
-            str(good_parser)
-        )
+        assert is_successful(good_parser), f"ERROR: unexpected {str(good_parser)}"
 
         # when
         result = good_parser.bind_result(_parse_state)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -123,17 +123,17 @@ def test_givin_good_files_when_verify_then_success(capsys):
 def test_given_good_input_when_webverify_then_success():
     # given
     bpmn = ""
-    with open("./test/resources/simple_example/test_bpmn.bpmn", "r") as bpmn_file:
+    with open("./test/resources/simple_example/test_bpmn.bpmn") as bpmn_file:
         for line in bpmn_file:
             bpmn += line
 
     cwp = ""
-    with open("./test/resources/simple_example/test_cwp.xml", "r") as cwp_file:
+    with open("./test/resources/simple_example/test_cwp.xml") as cwp_file:
         for line in cwp_file:
             cwp += line
 
     state = ""
-    with open("./test/resources/simple_example/state.txt", "r") as state_file:
+    with open("./test/resources/simple_example/state.txt") as state_file:
         for line in state_file:
             state += line
 
@@ -147,17 +147,17 @@ def test_given_good_input_when_webverify_then_success():
 def test_given_bad_input_when_webverify_then_failure():
     # given
     bpmn = ""
-    with open("./test/resources/simple_example/test_bpmn.bpmn", "r") as bpmn_file:
+    with open("./test/resources/simple_example/test_bpmn.bpmn") as bpmn_file:
         for line in bpmn_file:
             bpmn += line
 
     cwp = ""
-    with open("./test/resources/simple_example/test_cwp.xml", "r") as cwp_file:
+    with open("./test/resources/simple_example/test_cwp.xml") as cwp_file:
         for line in cwp_file:
             cwp += line
 
     state = ""
-    with open("./test/resources/simple_example/bad_state.txt", "r") as state_file:
+    with open("./test/resources/simple_example/bad_state.txt") as state_file:
         for line in state_file:
             state += line
     # when
@@ -174,7 +174,7 @@ def test_triggers_lambda_when_given_cloud_flag(mocker):
         "bpmncwpverify.cli._trigger_lambda",
         return_value=IOSuccess(
             json.load(
-                open("./test/resources/simple_example/lambda_output.json", "r"),
+                open("./test/resources/simple_example/lambda_output.json"),
                 object_hook=lambda obj: SpinVerificationReport(**obj),
             )
         ),
@@ -196,24 +196,24 @@ def test_assert_success_when_lambda_returns_success(mocker):
     mock_response = SimpleNamespace()
     mock_response.raise_for_status = lambda: None
     mock_response.json = lambda **kwargs: json.load(
-        open("./test/resources/simple_example/lambda_output.json", "r"),
+        open("./test/resources/simple_example/lambda_output.json"),
         object_hook=lambda obj: SpinVerificationReport(**obj),
     )
 
     mocker.patch("requests.post", return_value=mock_response)
 
     bpmn = ""
-    with open("./test/resources/simple_example/test_bpmn.bpmn", "r") as bpmn_file:
+    with open("./test/resources/simple_example/test_bpmn.bpmn") as bpmn_file:
         for line in bpmn_file:
             bpmn += line
 
     cwp = ""
-    with open("./test/resources/simple_example/test_cwp.xml", "r") as cwp_file:
+    with open("./test/resources/simple_example/test_cwp.xml") as cwp_file:
         for line in cwp_file:
             cwp += line
 
     state = ""
-    with open("./test/resources/simple_example/state.txt", "r") as state_file:
+    with open("./test/resources/simple_example/state.txt") as state_file:
         for line in state_file:
             state += line
 
@@ -235,17 +235,17 @@ def test_assert_failure_when_lambda_verification_fails(mocker):
     mocker.patch("requests.post", return_value=mock_response)
 
     bpmn = ""
-    with open("./test/resources/simple_example/test_bpmn.bpmn", "r") as bpmn_file:
+    with open("./test/resources/simple_example/test_bpmn.bpmn") as bpmn_file:
         for line in bpmn_file:
             bpmn += line
 
     cwp = ""
-    with open("./test/resources/simple_example/test_cwp.xml", "r") as cwp_file:
+    with open("./test/resources/simple_example/test_cwp.xml") as cwp_file:
         for line in cwp_file:
             cwp += line
 
     state = ""
-    with open("./test/resources/simple_example/state.txt", "r") as state_file:
+    with open("./test/resources/simple_example/state.txt") as state_file:
         for line in state_file:
             state += line
 
@@ -270,17 +270,17 @@ def test_assert_failure_when_lambda_returns_internal_server_error(mocker):
     mocker.patch("requests.post", return_value=mock_response)
 
     bpmn = ""
-    with open("./test/resources/simple_example/test_bpmn.bpmn", "r") as bpmn_file:
+    with open("./test/resources/simple_example/test_bpmn.bpmn") as bpmn_file:
         for line in bpmn_file:
             bpmn += line
 
     cwp = ""
-    with open("./test/resources/simple_example/test_cwp.xml", "r") as cwp_file:
+    with open("./test/resources/simple_example/test_cwp.xml") as cwp_file:
         for line in cwp_file:
             cwp += line
 
     state = ""
-    with open("./test/resources/simple_example/state.txt", "r") as state_file:
+    with open("./test/resources/simple_example/state.txt") as state_file:
         for line in state_file:
             state += line
 

--- a/test/test_lambda_handler.py
+++ b/test/test_lambda_handler.py
@@ -13,7 +13,7 @@ def test_lambda_handler_correctly_handles_good_input(mocker):
         "lambda_function.web_verify",
         return_value=IOSuccess(
             json.load(
-                open("./test/resources/simple_example/lambda_output.json", "r"),
+                open("./test/resources/simple_example/lambda_output.json"),
                 object_hook=lambda obj: SpinVerificationReport(**obj),
             )
         ),


### PR DESCRIPTION
mypy deprecated flags causing the pre-commit in GitHub actions to fail. The deprecated flags are removed, and a new flag is added to ruff for the same checks. These new checks triggered all the file changes--the mypy checks were not actually working.