### PR TITLE
Output readability

### DIFF
--- a/src/bpmncwpverify/builder/promela_builder.py
+++ b/src/bpmncwpverify/builder/promela_builder.py
@@ -111,15 +111,15 @@ def _get_variable_names(state: State) -> list[str]:
 def _get_print_type(type: str) -> str:
     match type:
         case "bit":
-            return "%d"
+            return "%u"
         case "bool":
             return "%d"
         case "byte":
-            return "%d"
+            return "%u"
         case "int":
             return "%d"
         case "short":
-            return "%d"
+            return "%hd"
         case _:
             return "%e"
 

--- a/src/bpmncwpverify/builder/promela_builder.py
+++ b/src/bpmncwpverify/builder/promela_builder.py
@@ -32,7 +32,9 @@ def _generate_logger(state: State, cwp: Cwp) -> str:
         loggerFunction.write_str(
             f":: {name} != old_{name} ->", NL_SINGLE, IndentAction.INC
         )
-        loggerFunction.write_str(f'printf("{name} = %e\\n", {name})', NL_SINGLE)
+        loggerFunction.write_str(
+            f'printf("{name} = {_get_print_type(name)}\\n", {name})', NL_SINGLE
+        )
         loggerFunction.write_str(f"old_{name} = {name}", NL_SINGLE)
         loggerFunction.write_str(":: else", NL_SINGLE, IndentAction.DEC)
         loggerFunction.write_str("fi;", NL_SINGLE, IndentAction.DEC)
@@ -51,12 +53,26 @@ def _generate_logger(state: State, cwp: Cwp) -> str:
     return str(loggerFunction)
 
 
+def _generate_state_dump(state: State) -> str:
+    state_dump = StringManager()
+    state_dump.write_str("inline stateDump(){", NL_SINGLE, IndentAction.INC)
+
+    for var in state.vars:
+        state_dump.write_str(
+            f'printf("{var.id} = {_get_print_type(var.type_)}\\n", {var.id})', NL_SINGLE
+        )
+
+    state_dump.write_str("}", NL_SINGLE, IndentAction.DEC)
+    return str(state_dump)
+
+
 def _generate_promela(state: State, cwp: Cwp, bpmn: Bpmn) -> Result[str, Error]:
     cwp_pml = _generate_cwp_promela(cwp, state)
     vars_pml = _generate_state_promela(state)
     logger_pml = _generate_logger(state, cwp)
+    state_dump_pml = _generate_state_dump(state)
     bpmn_pml = _generate_bpmn_promela(bpmn)
-    pml = f"{vars_pml}{cwp_pml}{logger_pml}{bpmn_pml}"
+    pml = f"{vars_pml}{cwp_pml}{logger_pml}{state_dump_pml}{bpmn_pml}"
     return Success(pml)
 
 
@@ -90,6 +106,22 @@ def _get_variable_names(state: State) -> list[str]:
     for var in state.vars:
         variableNames.append(var.id)
     return variableNames
+
+
+def _get_print_type(type: str) -> str:
+    match type:
+        case "bit":
+            return "%d"
+        case "bool":
+            return "%d"
+        case "byte":
+            return "%d"
+        case "int":
+            return "%d"
+        case "short":
+            return "%d"
+        case _:
+            return "%e"
 
 
 class PromelaBuilder:

--- a/src/bpmncwpverify/builder/promela_builder.py
+++ b/src/bpmncwpverify/builder/promela_builder.py
@@ -115,7 +115,7 @@ def _get_print_type(type: str) -> str:
         case "bool":
             return "%d"
         case "byte":
-            return "%u"
+            return "%hhu"
         case "int":
             return "%d"
         case "short":

--- a/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/bpmnmethods.py
@@ -22,9 +22,16 @@ def from_xml(root: Element, state: State) -> Result["Bpmn", Error]:
     # Build and add processes
     ##############
     processes = root.findall("bpmn:process", BPMN_XML_NAMESPACE)
+    collab = root.find("bpmn:collaboration", BPMN_XML_NAMESPACE)
+
+    if collab is not None:
+        participants = collab.findall("bpmn:participant", BPMN_XML_NAMESPACE)
+    else:
+        participants = []
+
     bpmn_builder = BpmnBuilder()
     for process_element in processes:
-        process = process_from_xml(process_element, state)
+        process = process_from_xml(process_element, participants, state)
         if not_(is_successful)(process):
             return cast(Result[Bpmn, Error], process)
         bpmn_builder = bpmn_builder.with_process(process.unwrap())
@@ -32,7 +39,6 @@ def from_xml(root: Element, state: State) -> Result["Bpmn", Error]:
     ##############
     # Build and add messages
     ##############
-    collab = root.find("bpmn:collaboration", BPMN_XML_NAMESPACE)
     if collab is not None:
         # TODO: write test for messages in the bpmn diagram
         bpmn_builder = bpmn_builder.with_process_elements()

--- a/src/bpmncwpverify/core/accessmethods/processmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/processmethods.py
@@ -16,11 +16,23 @@ from bpmncwpverify.core.error import Error
 from bpmncwpverify.core.state import State
 
 
-def from_xml(element: Element, state: State) -> Result["Process", Error]:
+def get_process_name(id: str, parts: list[Element]) -> str:
+    for part in parts:
+        if id == part.attrib.get("processRef"):
+            return part.attrib.get("name", id)
+
+    return id
+
+
+def from_xml(
+    element: Element, participants: list[Element], state: State
+) -> Result["Process", Error]:
     id = element.attrib.get("id")
     if not id:
         raise Exception("Id cannot be None")
-    name: str = element.attrib.get("name", id)
+
+    name: str = get_process_name(id, participants)
+
     builder = ProcessBuilder(id, name, state)
 
     for sub_element in element:

--- a/src/bpmncwpverify/core/counterexample.py
+++ b/src/bpmncwpverify/core/counterexample.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 
+from bpmncwpverify.core.bpmn import Bpmn
 from bpmncwpverify.core.error import Error
 from bpmncwpverify.util.stringmanager import NL_SINGLE, StringManager
 
@@ -10,12 +11,12 @@ class ErrorTrace:
     Class to represent an error trace.
     """
 
-    __slots__ = ["id", "changed_vars", "curr_cwp_state"]
+    __slots__ = ["id", "changed_vars", "cur_cwp_state", "related_variables"]
 
-    def __init__(self, id: str, changed_vars: list[str], curr_cwp_state: list[str]):
+    def __init__(self, id: str, changed_vars: list[str], cur_cwp_state: str):
         self.id = id
         self.changed_vars = changed_vars
-        self.curr_cwp_state = curr_cwp_state
+        self.cur_cwp_state = cur_cwp_state
 
 
 class CounterExample:
@@ -23,11 +24,19 @@ class CounterExample:
     Class to represent a counterexample.
     """
 
-    __slots__ = ["trace_steps", "error"]
+    __slots__ = ["trace_steps", "error", "issue", "vars"]
 
-    def __init__(self, trace_steps: list[ErrorTrace], error: type["Error"]):
+    def __init__(
+        self,
+        trace_steps: list[ErrorTrace],
+        error: type["Error"],
+        issue: str = "",
+        vars: list[str] = [],
+    ):
         self.trace_steps = trace_steps
         self.error = error.__name__
+        self.issue = issue
+        self.vars = vars
 
     def to_json(self) -> str:
         """
@@ -35,11 +44,13 @@ class CounterExample:
         """
         format = {
             "error": str(self.error),
+            "issue": self.issue,
+            "init variables": self.vars,
             "trace_steps": [
                 {
                     "id": step.id,
                     "changed_vars": step.changed_vars,
-                    "curr_cwp_state": step.curr_cwp_state,
+                    "cur_cwp_state": step.cur_cwp_state,
                 }
                 for step in self.trace_steps
             ],
@@ -48,7 +59,7 @@ class CounterExample:
 
     @staticmethod
     def generate_counterexample(
-        file_path: str, error: type["Error"]
+        file_path: str, error: type["Error"], bpmn: Bpmn
     ) -> "CounterExample":
         """
         Generate a counterexample from the given file path and error.
@@ -57,9 +68,10 @@ class CounterExample:
             ["spin", "-t", file_path], capture_output=True, text=True
         ).stdout
         filtered_str = CounterExample.filter_spin_trace(spin_trace_string)
-        steps = CounterExample.extract_steps(filtered_str)
+        vars = CounterExample.extract_init_variables(filtered_str)
+        counter_steps, issue = CounterExample.extract_steps_v_two(filtered_str, bpmn)
 
-        return CounterExample(steps, error)
+        return CounterExample(counter_steps, error, issue, vars)
 
     @staticmethod
     def filter_spin_trace(spin_trace_string: str) -> str:
@@ -69,49 +81,74 @@ class CounterExample:
         lines = spin_trace_string.splitlines()
         filtered_str = StringManager()
         for line in lines:
-            if line.startswith("spin:"):
+            if "spin:" in line:
+                filtered_str.write_str(line.split("spin:")[0])
                 break
             else:
                 filtered_str.write_str(line, NL_SINGLE)
         return str(filtered_str)
 
     @staticmethod
-    def extract_steps(filtered_str: str) -> list[ErrorTrace]:
-        """
-        Extract trace steps from the filtered string.
-        """
+    def extract_init_variables(filtered_str: str) -> list[str]:
         lines = filtered_str.splitlines()
-        steps: list[ErrorTrace] = []
-        line_index = 0
-        while line_index < len(lines):
-            id = ""
-            changed_vars: list[str] = []
-            curr_cwp_state: list[str] = []
-            if lines[line_index].startswith("ID:"):
-                id = lines[line_index].split(" ", 1)[1].strip()
-                line_index += 1
-                assert line_index < len(lines), (
-                    "line_index should never be out of bounds"
-                )
-                if lines[line_index].startswith("Changed vars:"):
-                    line_index += 1
-                    assert line_index < len(lines), (
-                        "line_index should never be out of bounds"
-                    )
-                    while not lines[line_index].startswith("Current state:"):
-                        changed_vars.append(lines[line_index].strip())
-                        line_index += 1
-                        assert line_index < len(lines), (
-                            "line_index should never be out of bounds"
-                        )
-                    while line_index < len(lines) and lines[line_index].startswith(
-                        "Current state:"
-                    ):
-                        curr_cwp_state.append(
-                            lines[line_index].split(" ", 2)[2].strip()
-                        )
-                        line_index += 1
-                steps.append(ErrorTrace(id, changed_vars, curr_cwp_state))
+        vars: list[str] = []
+
+        for line in lines:
+            if "ID:" in line or not line:
+                break
             else:
+                vars.append(line.strip())
+
+        return vars
+
+    @staticmethod
+    def extract_steps_v_two(
+        filtered_str: str, bpmn: Bpmn
+    ) -> tuple[list[ErrorTrace], str]:
+        lines = filtered_str.splitlines()
+        line_index = 0
+        steps: list[ErrorTrace] = []
+        id = ""
+        changed_variables: list[str] = []
+        state = ""
+        issue = ""
+
+        while line_index < len(lines):
+            if "ID: " in lines[line_index]:  # add one to index
+                id = lines[line_index].split(":", 1)[1].strip()
+
+                if "Process" in id:
+                    id = bpmn.processes[id].name
+                elif "StartEvent" in id:
+                    id = bpmn.id_to_element[id].name
+                elif "Activity" in id:
+                    id = bpmn.id_to_element[id].name
+                elif "Event" in id:
+                    id = bpmn.id_to_element[id].name
+                elif "Gateway" in id:
+                    id = bpmn.id_to_element[id].name
+
+                state = ""
                 line_index += 1
-        return steps
+
+            elif "Changed Vars:" in lines[line_index]:
+                changed_variables = []
+                line_index += 1
+                while ":" not in lines[line_index]:
+                    varaiable = lines[line_index].strip()
+                    changed_variables.append(varaiable)
+                    line_index += 1
+
+            elif "Current state:" in lines[line_index]:
+                state = lines[line_index].split(":", 1)[1].strip()
+                line_index += 1
+
+            else:
+                if "Assert:" in lines[line_index]:
+                    issue = lines[line_index].strip()
+                line_index += 1
+
+            if line_index == len(lines) or "ID: " in lines[line_index]:
+                steps.append(ErrorTrace(id, changed_variables, state))
+
+        return steps, issue

--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -12,6 +12,22 @@ class Error:
         pass
 
 
+class BpmnNoElementNameError(Error):
+    __slots__ = ["ids"]
+
+    def __init__(self, ids: list[str]) -> None:
+        super().__init__()
+        self.ids = ids
+
+
+class BpmnNoSwimLaneNameError(Error):
+    __slots__ = ["ids"]
+
+    def __init__(self, ids: list[str]) -> None:
+        super().__init__()
+        self.ids = ids
+
+
 class BpmnFlowIncomingError(Error):
     __slots__ = ["node_id"]
 
@@ -435,15 +451,13 @@ class SpinAssertionError(CounterExampleError):
     ):
         super().__init__(counter_example)
         self.list_of_error_maps = list_of_error_maps
+        self.counter_example = counter_example
 
 
-class SpinCoverageError(CounterExampleError):
+class SpinCoverageError(Error):
     __slots__ = ["coverage_errors"]
 
-    def __init__(
-        self, counter_example: str, coverage_errors: list[dict[str, str]]
-    ) -> None:
-        super().__init__(counter_example)
+    def __init__(self, coverage_errors: list[dict[str, str]]) -> None:
         self.coverage_errors = coverage_errors
 
 
@@ -459,15 +473,13 @@ class SpinInvalidEndStateError(CounterExampleError):
         self.list_of_error_maps = list_of_error_maps
 
 
-class SpinSyntaxError(CounterExampleError):
+class SpinSyntaxError(Error):
     __slots__ = ["list_of_error_maps"]
 
     def __init__(
         self,
-        counter_example: str,
         list_of_error_maps: list[dict[str, str]],
     ):
-        super().__init__(counter_example)
         self.list_of_error_maps = list_of_error_maps
 
 
@@ -593,6 +605,12 @@ class TypingNotNonBoolError(Error):
 
 def get_error_message(error: Error) -> str:
     match error:
+        case BpmnNoElementNameError(ids=ids):
+            return (
+                f"Bpmn error: {ids} must have a name that is different from their ID."
+            )
+        case BpmnNoSwimLaneNameError(ids=ids):
+            return f"Bpmn error: {ids} must have a swimlane with a name that is different from their ID"
         case BpmnFlowIncomingError(node_id=node_id):
             return f"Flow error: All flow objects other than start events, boundary events, and compensating activities must have an incoming sequence flow, if the process level includes any start or end events. node: {node_id}."
         case BpmnFlowNoIdError(element=element):
@@ -691,7 +709,9 @@ def get_error_message(error: Error) -> str:
             return (
                 f"ERROR: Unknown error occurred while sending request to lambda: {err}"
             )
-        case SpinAssertionError(list_of_error_maps=list_of_error_maps):
+        case SpinAssertionError(
+            counter_example=counter_example, list_of_error_maps=list_of_error_maps
+        ):
             errors: list[str] = []
             errors.append("Assertion Error:")
             errors.append(f"{len(list_of_error_maps)} error(s) occurred:")
@@ -699,6 +719,8 @@ def get_error_message(error: Error) -> str:
                 errors.append(
                     f"{idx + 1}: Assertion: {map['assertion']}, Depth info: {map['depth']}"
                 )
+            #    errors.append("Counter Example:")
+            errors.append(counter_example)
             return "\n".join(errors)
         case SpinCoverageError(coverage_errors=coverage_errors):
             return "\n".join(

--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -719,7 +719,7 @@ def get_error_message(error: Error) -> str:
                 errors.append(
                     f"{idx + 1}: Assertion: {map['assertion']}, Depth info: {map['depth']}"
                 )
-            #    errors.append("Counter Example:")
+
             errors.append(counter_example)
             return "\n".join(errors)
         case SpinCoverageError(coverage_errors=coverage_errors):

--- a/src/bpmncwpverify/core/spin.py
+++ b/src/bpmncwpverify/core/spin.py
@@ -4,6 +4,7 @@ import subprocess
 
 from returns.io import IOFailure, IOResult, IOSuccess, impure_safe
 from returns.pipeline import flow
+from returns.pointfree import bind_result
 from returns.result import Failure, Result, Success
 
 from bpmncwpverify.builder.promela_builder import PromelaBuilder
@@ -23,19 +24,29 @@ from bpmncwpverify.core.state import State
 from bpmncwpverify.util.file import write_file_contents
 
 
-def _process_spin_output(file_path: str, spin_report: str) -> IOResult[None, Error]:
+def _process_spin_output(
+    file_path: str, spin_report: str, bpmn: Bpmn
+) -> IOResult[None, Error]:
     spin_parser: SpinOutputParser = SpinOutputParser()
-    return flow(
-        spin_parser.check_syntax_errors(file_path, spin_report),
-        lambda _: spin_parser.check_invalid_end_state(file_path, spin_report),  # pyright: ignore[reportUnknownLambdaType]
-        lambda _: spin_parser.check_coverage_errors(file_path, spin_report),  # pyright: ignore[reportUnknownLambdaType]
-        lambda _: spin_parser.check_assertion_violation(file_path, spin_report),  # pyright: ignore[reportUnknownLambdaType]
-        lambda _: IOSuccess(None),  # pyright: ignore[reportUnknownLambdaType]
+    r: Result[None, Error] = flow(  # check this type one of these can return a string
+        spin_parser.check_syntax_errors(file_path, spin_report, bpmn),
+        bind_result(
+            lambda _: spin_parser.check_invalid_end_state(file_path, spin_report, bpmn)
+        ),  # pyright: ignore[reportUnknownLambdaType]
+        bind_result(
+            lambda _: spin_parser.check_coverage_errors(file_path, spin_report, bpmn)
+        ),  # pyright: ignore[reportUnknownLambdaType]
+        bind_result(
+            lambda _: spin_parser.check_assertion_violation(
+                file_path, spin_report, bpmn
+            )
+        ),  # pyright: ignore[reportUnknownLambdaType]
     )
+    return IOResult.from_result(r)
 
 
 def _run_spin(
-    promela: str, file_path: str, cli_args: list[str]
+    promela: str, file_path: str, cli_args: list[str], bpmn: Bpmn
 ) -> IOResult["SpinVerificationReport", Error]:
     file_name: str = os.path.basename(file_path)
     file_dir: str = os.path.dirname(file_path)
@@ -56,7 +67,7 @@ def _run_spin(
     )
 
     result: IOResult[SpinVerificationReport, Error] = spin_result.bind(  # pyright: ignore[reportUnknownMemberType]
-        lambda spin_report: _process_spin_output(file_path, spin_report).bind(  # pyright: ignore[reportUnknownMemberType]
+        lambda spin_report: _process_spin_output(file_path, spin_report, bpmn).bind(  # pyright: ignore[reportUnknownMemberType]
             lambda _: IOSuccess(
                 SpinVerificationReport(file_path, promela, cli_args, spin_report)
             )
@@ -92,11 +103,11 @@ class SpinVerificationReportBuilder:
             NotInitializedError("SpinVerificationReportBuilder.spin_cli_args")
         )
 
-    def build(self) -> IOResult[SpinVerificationReport, Error]:
+    def build(self, bpmn: Bpmn) -> IOResult[SpinVerificationReport, Error]:
         spin_result: IOResult[SpinVerificationReport, Error] = self.promela.bind(  # pyright: ignore[reportUnknownMemberType]
             lambda promela: self.file_path.bind(  # pyright: ignore[reportUnknownMemberType]
                 lambda filename: self.spin_cli_args.bind(  # pyright: ignore[reportUnknownMemberType]
-                    lambda cli_args: _run_spin(promela, filename, cli_args)
+                    lambda cli_args: _run_spin(promela, filename, cli_args, bpmn)
                 )
             )
         )
@@ -127,12 +138,12 @@ class SpinOutputParser:
         ]
 
     def check_invalid_end_state(
-        self, file_path: str, spin_msg: str
+        self, file_path: str, spin_msg: str, bpmn: Bpmn
     ) -> Result[None, Error]:
         errors = self._get_re_matches(r"invalid end state \((?P<info>.*)\)", spin_msg)
 
         counter_example = CounterExample.generate_counterexample(
-            file_path, SpinInvalidEndStateError
+            file_path, SpinInvalidEndStateError, bpmn
         )
 
         return (
@@ -142,14 +153,14 @@ class SpinOutputParser:
         )
 
     def check_assertion_violation(
-        self, file_path: str, spin_msg: str
+        self, file_path: str, spin_msg: str, bpmn: Bpmn
     ) -> Result[None, Error]:
         errors = self._get_re_matches(
             r"assertion violated \(?(?P<assertion>[^\s)]*)\)? (?P<depth>.*)", spin_msg
         )
 
         counter_example = CounterExample.generate_counterexample(
-            file_path, SpinAssertionError
+            file_path, SpinAssertionError, bpmn
         )
 
         return (
@@ -158,24 +169,18 @@ class SpinOutputParser:
             else Success(None)
         )
 
-    def check_syntax_errors(self, file_path: str, spin_msg: str) -> Result[str, Error]:
+    def check_syntax_errors(
+        self, file_path: str, spin_msg: str, bpmn: Bpmn
+    ) -> Result[str, Error]:
         errors = self._get_re_matches(
             r"spin: (?P<file_path>.*?):(?P<line_number>\d+),\sError: (?P<error_msg>.*)",
             spin_msg,
         )
 
-        counter_example = CounterExample.generate_counterexample(
-            file_path, SpinAssertionError
-        )
-
-        return (
-            Failure(SpinSyntaxError(counter_example.to_json(), errors))
-            if errors
-            else Success(spin_msg)
-        )
+        return Failure(SpinSyntaxError(errors)) if errors else Success(spin_msg)
 
     def check_coverage_errors(
-        self, file_path: str, spin_msg: str
+        self, file_path: str, spin_msg: str, bpmn: Bpmn
     ) -> Result[None, Error]:
         # Regular expression to match proctype and init blocks, excluding never claims
         block_pattern = re.compile(
@@ -213,12 +218,8 @@ class SpinOutputParser:
                     }
                 )
 
-        counter_example = CounterExample.generate_counterexample(
-            file_path, SpinAssertionError
-        )
-
         return (
-            Failure(SpinCoverageError(counter_example.to_json(), detailed_errors))
+            Failure(SpinCoverageError(detailed_errors))
             if detailed_errors
             else Success(None)
         )
@@ -241,6 +242,6 @@ def verify_with_spin(
         lambda promela: spin_verification_report_builder.with_file_name(OUTPUT_FILE)
         .with_promela(promela)
         .with_spin_cli_args(["-run", "-noclaim"])
-        .build()
+        .build(bpmn)
     )
     return result

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -259,7 +259,10 @@ class PromelaGenVisitor(BpmnVisitor):
                     sm.write_str(f"putToken({put_loc})", NL_SINGLE)
                 sm.write_str("", indent_action=IndentAction.DEC)
 
-        sm.write_str(":: atomic{else -> assert false}", NL_SINGLE)
+        sm.write_str(
+            ':: atomic{else -> printf("Assert: No viable path to take"); assert false}',
+            NL_SINGLE,
+        )
         sm.write_str("fi", NL_SINGLE)
         return sm
 
@@ -503,6 +506,9 @@ class PromelaGenVisitor(BpmnVisitor):
     def visit_bpmn(self, bpmn: Bpmn) -> bool:
         self.defs.write_str(HELPER_FUNCS_STR, NL_DOUBLE)
         self.init_proc_contents.write_str("init {", NL_SINGLE, IndentAction.INC)
+        # vars = vars.split("//**********VARIABLE DECLARATION************//\n")[1]
+        # vars = vars.replace("\n", "\\n")
+        # self.init_proc_contents.write_str(f'printf("{vars}\\n")', NL_SINGLE)
         return True
 
     def end_visit_bpmn(self, bpmn: Bpmn) -> None:

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -506,9 +506,7 @@ class PromelaGenVisitor(BpmnVisitor):
     def visit_bpmn(self, bpmn: Bpmn) -> bool:
         self.defs.write_str(HELPER_FUNCS_STR, NL_DOUBLE)
         self.init_proc_contents.write_str("init {", NL_SINGLE, IndentAction.INC)
-        # vars = vars.split("//**********VARIABLE DECLARATION************//\n")[1]
-        # vars = vars.replace("\n", "\\n")
-        # self.init_proc_contents.write_str(f'printf("{vars}\\n")', NL_SINGLE)
+        self.init_proc_contents.write_str("stateDump()", NL_SINGLE)
         return True
 
     def end_visit_bpmn(self, bpmn: Bpmn) -> None:

--- a/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidate.py
+++ b/src/bpmncwpverify/visitors/bpmnchecks/bpmnvalidate.py
@@ -3,7 +3,12 @@ from returns.pointfree import bind_result
 from returns.result import Failure, Result, Success
 
 from bpmncwpverify.core.bpmn import Bpmn, Process
-from bpmncwpverify.core.error import BpmnMsgFlowSamePoolError, Error
+from bpmncwpverify.core.error import (
+    BpmnMsgFlowSamePoolError,
+    BpmnNoElementNameError,
+    BpmnNoSwimLaneNameError,
+    Error,
+)
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidations import (
     validate_start_end_events,
 )
@@ -20,6 +25,15 @@ from bpmncwpverify.visitors.bpmnchecks.checkmethods import (
 
 
 def validate_bpmn(bpmn: Bpmn) -> Result[Bpmn, Error]:
+    return flow(
+        bpmn,
+        validate_msg_flow_pool,
+        bind_result(validate_process_names),
+        bind_result(validate_element_names),
+    )
+
+
+def validate_msg_flow_pool(bpmn: Bpmn) -> Result[Bpmn, Error]:
     for msg in bpmn.inter_process_msgs.values():
         for process in bpmn.processes.values():
             if (
@@ -27,6 +41,38 @@ def validate_bpmn(bpmn: Bpmn) -> Result[Bpmn, Error]:
                 and msg.source_node.id in process.all_items()
             ):
                 return Failure(BpmnMsgFlowSamePoolError(msg.id))
+
+    return Success(bpmn)
+
+
+def validate_process_names(bpmn: Bpmn) -> Result[Bpmn, Error]:
+    no_name_ids: list[str] = []
+    for id in bpmn.processes.values():
+        process_name = id.name
+        process_id = id.id
+
+        if process_name == process_id and process_id.startswith("Process"):
+            no_name_ids.append(process_id)
+
+    if no_name_ids:
+        return Failure(BpmnNoSwimLaneNameError(no_name_ids))
+
+    return Success(bpmn)
+
+
+def validate_element_names(bpmn: Bpmn) -> Result[Bpmn, Error]:
+    ELEMENTS = ("Event", "Activity", "Gateway")
+    no_name_ids: list[str] = []
+    for id in bpmn.id_to_element.values():
+        element_name = id.name
+        element_id = id.id
+
+        if element_name == element_id and element_id.startswith(ELEMENTS):
+            no_name_ids.append(element_id)
+
+    if no_name_ids:
+        return Failure(BpmnNoElementNameError(no_name_ids))
+
     return Success(bpmn)
 
 

--- a/test/builder/test_promela_builder.py
+++ b/test/builder/test_promela_builder.py
@@ -3,6 +3,7 @@ import pytest
 
 from bpmncwpverify.builder.promela_builder import (
     _generate_logger,
+    _generate_state_dump,
     _generate_state_promela,
     _get_variable_names,
 )
@@ -69,6 +70,57 @@ def test_variable_name_extractor(mocker):
     result = _get_variable_names(state)
 
     assert result == [1, 2]
+
+
+def test_state_dump_int(mocker):
+    vars = [
+        mocker.Mock(id="v1", type_="int", init="1"),
+        mocker.Mock(id="v2", type_="int", init="2"),
+    ]
+
+    state = mocker.Mock()
+    state.vars = vars
+
+    result = _generate_state_dump(state)
+
+    assert (
+        result
+        == 'inline stateDump(){\n\tprintf("v1 = %d\\n", v1)\n\tprintf("v2 = %d\\n", v2)\n}\n'
+    )
+
+
+def test_state_dump_bool(mocker):
+    vars = [
+        mocker.Mock(id="v1", type_="bool", init="true"),
+        mocker.Mock(id="v2", type_="bool", init="true"),
+    ]
+
+    state = mocker.Mock()
+    state.vars = vars
+
+    result = _generate_state_dump(state)
+
+    assert (
+        result
+        == 'inline stateDump(){\n\tprintf("v1 = %d\\n", v1)\n\tprintf("v2 = %d\\n", v2)\n}\n'
+    )
+
+
+def test_state_dump_enum(mocker):
+    vars = [
+        mocker.Mock(id="v1", type_="BinDecision", init="yes"),
+        mocker.Mock(id="v2", type_="BinDecision", init="no"),
+    ]
+
+    state = mocker.Mock()
+    state.vars = vars
+
+    result = _generate_state_dump(state)
+
+    assert (
+        result
+        == 'inline stateDump(){\n\tprintf("v1 = %e\\n", v1)\n\tprintf("v2 = %e\\n", v2)\n}\n'
+    )
 
 
 def test_generate_promela(mocker):

--- a/test/core/test_bpmn.py
+++ b/test/core/test_bpmn.py
@@ -20,14 +20,14 @@ def create_bpmn_definition():
             "targetNamespace": "http://example.com/schema/bpmn",
         },
     )
-    SubElement(root, "bpmn:collaboration", attrib={"id": "Collaboration_1"})
-    return root
+    collab = SubElement(root, "bpmn:collaboration", attrib={"id": "Collaboration_1"})
+    return root, collab
 
 
-def add_process(root: Element, process_id="Process_1"):
+def add_process(collab: Element, process_id="Process_1"):
     """Add a collaboration and participant to the BPMN definition."""
     SubElement(
-        root,
+        collab,
         "bpmn:participant",
         attrib={
             "id": "Participant_1",
@@ -48,8 +48,8 @@ def add_process_with_elements(root, elements):
 
 def test_complete_bpmn_with_no_start_or_end_event():
     state = StateBuilder().build()
-    root = create_bpmn_definition()
-    add_process(root)
+    root, collab = create_bpmn_definition()
+    add_process(collab)
     task = Element("bpmn:task", attrib={"id": "Task_1", "name": "Test Task"})
     add_process_with_elements(root, [task])
 
@@ -64,8 +64,8 @@ def test_complete_bpmn_with_no_start_or_end_event():
 
 def test_complete_bpmn_with_no_end_event():
     state = StateBuilder().build()
-    root = create_bpmn_definition()
-    add_process(root)
+    root, collab = create_bpmn_definition()
+    add_process(collab)
 
     start_event = Element("bpmn:startEvent", attrib={"id": "se1"})
     outgoing = SubElement(start_event, "bpmn:outgoing")
@@ -89,8 +89,8 @@ def test_complete_bpmn_with_no_end_event():
 
 def test_complete_bpmn_with_good_process():
     state = StateBuilder().build()
-    root = create_bpmn_definition()
-    add_process(root)
+    root, collab = create_bpmn_definition()
+    add_process(collab)
 
     start_event = Element("bpmn:startEvent", attrib={"id": "se1"})
     outgoing = SubElement(start_event, "bpmn:outgoing")
@@ -108,6 +108,7 @@ def test_complete_bpmn_with_good_process():
     result = from_xml(parsed_root, state)
 
     assert isinstance(result, Success)
+    assert result.unwrap().processes["Process_1"].name == "Test Participant"
 
 
 def test_from_xml(mocker):

--- a/test/core/test_counterexample.py
+++ b/test/core/test_counterexample.py
@@ -1,5 +1,7 @@
+# type: ignore
 import pytest
 
+from bpmncwpverify.core.bpmn import Bpmn
 from bpmncwpverify.core.counterexample import NL_SINGLE, CounterExample
 from bpmncwpverify.core.error import Error
 
@@ -20,7 +22,7 @@ def test_generate_counter_example(mocker):
     )
 
     CounterExample.generate_counterexample(
-        mocker.Mock(), mocker.MagicMock(__name__="test")
+        mocker.Mock(), mocker.MagicMock(__name__="test"), mocker.MagicMock()
     )
 
     mock_filter_spin_trace.assert_called_once_with("test_str")
@@ -59,10 +61,19 @@ def test_counterexample_constructor(mocker):
     assert ce.error == "SubError"
 
 
-def test_counterexample_extract_steps():
-    test_string = """ID: test_id\nChanged vars:\ntest_var1\ntest_var2\nCurrent state: test_state1"""
-    steps = CounterExample.extract_steps(test_string)
+def test_counterexample_extract_steps(mocker):
+    test_string = """ID: Event_1\nChanged Vars:\ntest_var1\ntest_var2\nCurrent state: test_state1"""
+    bpmn = Bpmn()
+    mock_element = mocker.MagicMock()
+    mock_element.id = "Event_1"
+    mock_element.name = "start"
+
+    bpmn.id_to_element[mock_element.id] = mock_element
+
+    steps, issue = CounterExample.extract_steps_v_two(test_string, bpmn)
+
+    assert issue == ""
     assert len(steps) == 1
-    assert steps[0].id == "test_id"
+    assert steps[0].id == "start"
     assert steps[0].changed_vars == ["test_var1", "test_var2"]
-    assert steps[0].curr_cwp_state == ["test_state1"]
+    assert steps[0].cur_cwp_state == "test_state1"

--- a/test/core/test_error.py
+++ b/test/core/test_error.py
@@ -21,6 +21,8 @@ from bpmncwpverify.core.error import (
     BpmnMsgStartEventError,
     BpmnMsgTargetError,
     BpmnNodeTypeError,
+    BpmnNoElementNameError,
+    BpmnNoSwimLaneNameError,
     BpmnSeqFlowEndEventError,
     BpmnSeqFlowNoExprError,
     BpmnStructureError,
@@ -64,6 +66,14 @@ from bpmncwpverify.core.error import (
 )
 
 test_inputs: list[tuple[Error, str]] = [
+    (
+        BpmnNoElementNameError(["Event_4kd93"]),
+        "Bpmn error: ['Event_4kd93'] must have a name that is different from their ID.",
+    ),
+    (
+        BpmnNoSwimLaneNameError(["Proces_32kdf8"]),
+        "Bpmn error: ['Proces_32kdf8'] must have a swimlane with a name that is different from their ID",
+    ),
     (
         BpmnFlowIncomingError("node_id"),
         "Flow error: All flow objects other than start events, boundary events, and compensating activities must have an incoming sequence flow, if the process level includes any start or end events. node: node_id.",
@@ -231,12 +241,11 @@ test_inputs: list[tuple[Error, str]] = [
                 {"assertion": "test_assertion2", "depth": "test_depth2"},
             ],
         ),
-        "Assertion Error:\n2 error(s) occurred:\n1: Assertion: test_assertion1, Depth info: test_depth1\n2: Assertion: test_assertion2, Depth info: test_depth2",
+        "Assertion Error:\n2 error(s) occurred:\n1: Assertion: test_assertion1, Depth info: test_depth1\n2: Assertion: test_assertion2, Depth info: test_depth2\n",
     ),
     (NotInitializedError("x"), "ERROR: 'x' is not initialized"),
     (
         SpinCoverageError(
-            "",
             [
                 {
                     "proctype": "test_proctype",
@@ -254,7 +263,6 @@ test_inputs: list[tuple[Error, str]] = [
     ),
     (
         SpinSyntaxError(
-            "",
             [
                 {
                     "line_number": "1",
@@ -299,6 +307,8 @@ test_inputs: list[tuple[Error, str]] = [
 ]
 
 test_ids: list[str] = [
+    "BpmnNoElementNameError",
+    "BpmnNoSwimLaneNameError",
     "BpmnFlowIncomingError",
     "BpmnFlowNoIdError",
     "BpmnFlowOutgoingError",

--- a/test/core/test_spin.py
+++ b/test/core/test_spin.py
@@ -3,6 +3,7 @@
 import pytest
 from returns.result import Failure, Success
 
+from bpmncwpverify.core.bpmn import Bpmn
 from bpmncwpverify.core.spin import SpinOutputParser
 
 
@@ -19,16 +20,16 @@ def mock_generate_counter_example(mocker):
 def test_check_syntax_errors(mock_generate_counter_example):
     mock_generate_counter_example
     spin_output = SpinOutputParser()
+    bpmn = Bpmn()
     s = """
     spin: test/resources/simple_example/valid_output.pml:55, Error: syntax error    saw ''}' = 125'
     spin: test/resources/simple_example/valid_output.pml:116, Error: missing '}' ?
     """
 
-    result = spin_output.check_syntax_errors("", s)
+    result = spin_output.check_syntax_errors("", s, bpmn)
 
     assert isinstance(result, Failure)
     result = result.failure()
-    assert result.get_counter_example() == "test_json"
     assert (
         result.list_of_error_maps[0]["file_path"]
         == "test/resources/simple_example/valid_output.pml"
@@ -48,6 +49,7 @@ def test_check_syntax_errors(mock_generate_counter_example):
 def test_check_syntax_errors_none(mock_generate_counter_example):
     mock_generate_counter_example
     spin_output = SpinOutputParser()
+    bpmn = Bpmn()
     s = """
         (Spin Version 6.5.2 -- 6 December 2019)
                 + Partial Order Reduction
@@ -60,13 +62,14 @@ def test_check_syntax_errors_none(mock_generate_counter_example):
         ...
     """
 
-    result = spin_output.check_syntax_errors("", s)
+    result = spin_output.check_syntax_errors("", s, bpmn)
 
     assert isinstance(result, Success)
 
 
 def test_has_uncovered_states(mock_generate_counter_example):
     mock_generate_counter_example
+    bpmn = Bpmn()
     spin_output = """
 
         Full statespace search for:
@@ -112,10 +115,9 @@ def test_has_uncovered_states(mock_generate_counter_example):
                 (1 of 7 states)
     """
     spin_obj = SpinOutputParser()
-    result = spin_obj.check_coverage_errors("", spin_output)
+    result = spin_obj.check_coverage_errors("", spin_output, bpmn)
     assert isinstance(result, Failure)
 
-    assert result.failure().get_counter_example() == "test_json"
     errors = result.failure().coverage_errors
     assert errors[0]["proctype"] == "testproc"
     assert errors[0]["file"] == "test.pml"
@@ -147,6 +149,7 @@ def test_has_uncovered_states(mock_generate_counter_example):
 
 def test_has_no_uncovered_states(mock_generate_counter_example):
     mock_generate_counter_example
+    bpmn = Bpmn()
     spin_output = """
     Full statespace search for:
             never claim             - (none specified)
@@ -181,13 +184,14 @@ def test_has_no_uncovered_states(mock_generate_counter_example):
     """
 
     spin_obj = SpinOutputParser()
-    result = spin_obj.check_coverage_errors("", spin_output)
+    result = spin_obj.check_coverage_errors("", spin_output, bpmn)
     assert isinstance(result, Success)
 
 
 def test_check_invalid_end_state(mock_generate_counter_example):
     mock_generate_counter_example
     spin_output = SpinOutputParser()
+    bpmn = Bpmn()
     s = """
         pan:1: invalid end state (at depth -1)
         pan: wrote first.pml.trail
@@ -203,7 +207,7 @@ def test_check_invalid_end_state(mock_generate_counter_example):
                 invalid end states      +
     """
 
-    result = spin_output.check_invalid_end_state("", s)
+    result = spin_output.check_invalid_end_state("", s, bpmn)
 
     assert isinstance(result, Failure)
     result = result.failure()
@@ -214,6 +218,7 @@ def test_check_invalid_end_state(mock_generate_counter_example):
 def test_check_invalid_end_state_none(mock_generate_counter_example):
     mock_generate_counter_example
     spin_output = SpinOutputParser()
+    bpmn = Bpmn()
     s = """
         (Spin Version 6.5.2 -- 6 December 2019)
                 + Partial Order Reduction
@@ -226,7 +231,7 @@ def test_check_invalid_end_state_none(mock_generate_counter_example):
         ...
     """
 
-    result = spin_output.check_invalid_end_state("", s)
+    result = spin_output.check_invalid_end_state("", s, bpmn)
 
     assert isinstance(result, Success)
 
@@ -234,11 +239,12 @@ def test_check_invalid_end_state_none(mock_generate_counter_example):
 def test_check_assertion_violation(mock_generate_counter_example):
     mock_generate_counter_example
     spin_output = SpinOutputParser()
+    bpmn = Bpmn()
     s = """
         pan:1: assertion violated (_nr_pr==3) (at depth 0)
     """
 
-    result = spin_output.check_assertion_violation("", s)
+    result = spin_output.check_assertion_violation("", s, bpmn)
 
     assert isinstance(result, Failure)
     result = result.failure()
@@ -249,7 +255,7 @@ def test_check_assertion_violation(mock_generate_counter_example):
         pan: wrote verification.pml.trail
     """
 
-    result = spin_output.check_assertion_violation("", s)
+    result = spin_output.check_assertion_violation("", s, bpmn)
 
     assert isinstance(result, Failure)
     result = result.failure()
@@ -259,6 +265,7 @@ def test_check_assertion_violation(mock_generate_counter_example):
 def test_check_assertion_violation_none(mock_generate_counter_example):
     mock_generate_counter_example
     spin_output = SpinOutputParser()
+    bpmn = Bpmn()
     s = """
         (Spin Version 6.5.2 -- 6 December 2019)
                 + Partial Order Reduction
@@ -271,6 +278,6 @@ def test_check_assertion_violation_none(mock_generate_counter_example):
         ...
     """
 
-    result = spin_output.check_assertion_violation("", s)
+    result = spin_output.check_assertion_violation("", s, bpmn)
 
     assert isinstance(result, Success)

--- a/test/resources/phware/workflow_good.bpmn
+++ b/test/resources/phware/workflow_good.bpmn
@@ -1,0 +1,684 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_07fgnzt" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="3543595" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:collaboration id="Collaboration_1cy17wr">
+    <bpmn:participant id="Participant_0kylnmw" name="Clinicians" processRef="Process_1rkaxxw" />
+    <bpmn:participant id="Participant_1b7yqru" name="AI cloud server" processRef="Process_0qvzd4w" />
+    <bpmn:participant id="Participant_0zelsdj" name="Patient-caregiver" processRef="Process_1flbpwq" />
+    <bpmn:messageFlow id="Flow_0gy5dgg" sourceRef="Event_1qmt0d1" targetRef="Event_1bg3bap" />
+    <bpmn:messageFlow id="Flow_0so3xgl" sourceRef="Activity_16mgbz6" targetRef="Event_0mqix7y" />
+    <bpmn:messageFlow id="Flow_0rcqwgc" sourceRef="Activity_0pl73xy" targetRef="Event_1v0tpdm" />
+    <bpmn:messageFlow id="Flow_15qty2a" sourceRef="Activity_19u2yz3" targetRef="Event_0hqgm9w" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1rkaxxw" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1ix971p" name="pt + COVID-19">
+      <bpmn:outgoing>Flow_0l518mv</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_11icm0p" name="01- Doc-Nurse Examine pt">
+      <bpmn:documentation>    assert(sevNeed != discharge)
+    assert(sevNeed != expired)
+    if
+    :: true -&gt; sevNeed = homeCare
+    :: ((sevNeed == patientNeedInit) || (trndSevNeed == outsideHomeCare)) -&gt; sevNeed = outsideHomeCare
+    :: ((sevNeed != patientNeedInit) &amp;&amp; (trndSevNeed == homeCare)) -&gt; sevNeed = discharge
+    fi
+    trndSevNeed = sevNeed</bpmn:documentation>
+      <bpmn:incoming>Flow_0l518mv</bpmn:incoming>
+      <bpmn:incoming>Flow_0jz2w66</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vil2qp</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="Gateway_12crsx7" name="Xor5 sevLvl">
+      <bpmn:incoming>Flow_1vil2qp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1i2f31g</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1byrxyc</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1aatpfx</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Activity_16mgbz6" name="02- Doc order NIH homecare, RPM with PHware">
+      <bpmn:incoming>Flow_1byrxyc</bpmn:incoming>
+      <bpmn:outgoing>Flow_09uqcye</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_1eqejkq" name="pt discharged">
+      <bpmn:incoming>Flow_1aatpfx</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:intermediateCatchEvent id="Event_0hqgm9w" name="EventName0h">
+      <bpmn:incoming>Flow_0n35392</bpmn:incoming>
+      <bpmn:incoming>Flow_09uqcye</bpmn:incoming>
+      <bpmn:incoming>Flow_0mw4npb</bpmn:incoming>
+      <bpmn:incoming>Flow_1evs2n3</bpmn:incoming>
+      <bpmn:outgoing>Flow_18hg8nu</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1mpya5g" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:exclusiveGateway id="Gateway_1s4qrvx" name="Xor8 alert">
+      <bpmn:incoming>Flow_18hg8nu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1arg57d</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0mq8ktv</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Activity_1f3c6ct" name="07-Doc-Nurse review vitals and exam schedule">
+      <bpmn:documentation>alert = no
+    if
+    :: examTime == scheduled -&gt; examTime = now
+    :: true
+    fi</bpmn:documentation>
+      <bpmn:incoming>Flow_0mq8ktv</bpmn:incoming>
+      <bpmn:outgoing>Flow_09z1r76</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="Gateway_16cy5xh" name="Xor10 exam orders">
+      <bpmn:incoming>Flow_09z1r76</bpmn:incoming>
+      <bpmn:outgoing>Flow_0n35392</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1rfqfky</bpmn:outgoing>
+      <bpmn:outgoing>Flow_15bkrk6</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0emq1yg</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Activity_05llwq4" name="08b- Scheduler schedule routine exam and inform pt">
+      <bpmn:documentation>if
+        :: true -&gt; examTime = scheduled
+    fi</bpmn:documentation>
+      <bpmn:incoming>Flow_1rfqfky</bpmn:incoming>
+      <bpmn:incoming>Flow_189nm76</bpmn:incoming>
+      <bpmn:outgoing>Flow_0q85pgz</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="Gateway_1gkv1yl" name="Xor11 examTime=now">
+      <bpmn:incoming>Flow_0q85pgz</bpmn:incoming>
+      <bpmn:incoming>Flow_0jccwa3</bpmn:incoming>
+      <bpmn:incoming>Flow_0emq1yg</bpmn:incoming>
+      <bpmn:incoming>Flow_0najxqy</bpmn:incoming>
+      <bpmn:outgoing>Flow_1evs2n3</bpmn:outgoing>
+      <bpmn:outgoing>Flow_12k9phr</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Activity_0pmtxeh" name="07a - Doc-Nurse review alert, vitals, exam schedule and home situation">
+      <bpmn:documentation>alert = no
+    if
+    :: examTime == scheduled -&gt; examTime = now
+    :: true
+    fi</bpmn:documentation>
+      <bpmn:incoming>Flow_1arg57d</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wumukp</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="Gateway_1yy3ulw" name="Xor9 exam&#10;orders">
+      <bpmn:incoming>Flow_0wumukp</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ugiucz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_189nm76</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0najxqy</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0mw4npb</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="Event_0l0nbsa" name="pt discharged1">
+      <bpmn:incoming>Flow_00vh7e4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_15twws8" name="03- Doc order ambulatory care or hospital admit">
+      <bpmn:documentation>assert(sevNeed != discharge)
+    assert(sevNeed != expired)
+    if
+    :: true -&gt; sevNeed = expired
+    :: true -&gt; sevNeed = discharge
+    fi
+    trndSevNeed = sevNeed</bpmn:documentation>
+      <bpmn:incoming>Flow_1i2f31g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0if4pkb</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="Gateway_169v3vp" name="Xor4 fatality">
+      <bpmn:incoming>Flow_0if4pkb</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ovofms</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00vh7e4</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:intermediateCatchEvent id="Event_1bg3bap" name="EventName1b">
+      <bpmn:incoming>Flow_12k9phr</bpmn:incoming>
+      <bpmn:outgoing>Flow_0jz2w66</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1d9qbno" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Activity_04tpysh" name="08a- Scheduler set up exam now and inform pt">
+      <bpmn:documentation>if
+        :: true -&gt; examTime = now
+    fi</bpmn:documentation>
+      <bpmn:incoming>Flow_0ugiucz</bpmn:incoming>
+      <bpmn:incoming>Flow_15bkrk6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0jccwa3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0l518mv" sourceRef="StartEvent_1ix971p" targetRef="Activity_11icm0p" />
+    <bpmn:sequenceFlow id="Flow_1vil2qp" sourceRef="Activity_11icm0p" targetRef="Gateway_12crsx7" />
+    <bpmn:sequenceFlow id="Flow_1i2f31g" name="sevNeed ==outsideHomeCare" sourceRef="Gateway_12crsx7" targetRef="Activity_15twws8" />
+    <bpmn:sequenceFlow id="Flow_1byrxyc" name="sevNeed ==homeCare" sourceRef="Gateway_12crsx7" targetRef="Activity_16mgbz6" />
+    <bpmn:sequenceFlow id="Flow_1aatpfx" name="sevNeed == discharge" sourceRef="Gateway_12crsx7" targetRef="Event_1eqejkq" />
+    <bpmn:sequenceFlow id="Flow_0if4pkb" sourceRef="Activity_15twws8" targetRef="Gateway_169v3vp" />
+    <bpmn:sequenceFlow id="Flow_0ovofms" name="sevNeed == expired" sourceRef="Gateway_169v3vp" targetRef="Event_0685ddn" />
+    <bpmn:sequenceFlow id="Flow_00vh7e4" name="sevNeed == discharge" sourceRef="Gateway_169v3vp" targetRef="Event_0l0nbsa" />
+    <bpmn:sequenceFlow id="Flow_18hg8nu" sourceRef="Event_0hqgm9w" targetRef="Gateway_1s4qrvx" />
+    <bpmn:sequenceFlow id="Flow_1arg57d" name="alert == yes" sourceRef="Gateway_1s4qrvx" targetRef="Activity_0pmtxeh" />
+    <bpmn:sequenceFlow id="Flow_0mq8ktv" name="alert == no" sourceRef="Gateway_1s4qrvx" targetRef="Activity_1f3c6ct" />
+    <bpmn:sequenceFlow id="Flow_09z1r76" sourceRef="Activity_1f3c6ct" targetRef="Gateway_16cy5xh" />
+    <bpmn:sequenceFlow id="Flow_0n35392" name="trndSevNeed ==outsideHomeCare" sourceRef="Gateway_16cy5xh" targetRef="Event_0hqgm9w" />
+    <bpmn:sequenceFlow id="Flow_1rfqfky" name="trndSevNeed&#10;==outsideHomeCare &#38;&#38; examTime == unscheduled" sourceRef="Gateway_16cy5xh" targetRef="Activity_05llwq4" />
+    <bpmn:sequenceFlow id="Flow_0q85pgz" name="examTime&#10;!=now" sourceRef="Activity_05llwq4" targetRef="Gateway_1gkv1yl" />
+    <bpmn:sequenceFlow id="Flow_0wumukp" sourceRef="Activity_0pmtxeh" targetRef="Gateway_1yy3ulw" />
+    <bpmn:sequenceFlow id="Flow_0ugiucz" name="trndSevNeed ==outsideHomeCare" sourceRef="Gateway_1yy3ulw" targetRef="Activity_04tpysh" />
+    <bpmn:sequenceFlow id="Flow_0jccwa3" name="examTime == now" sourceRef="Activity_04tpysh" targetRef="Gateway_1gkv1yl" />
+    <bpmn:sequenceFlow id="Flow_189nm76" name="trndSevNeed&#10;==outsideHomeCare &#38;&#38; examTime == unscheduled" sourceRef="Gateway_1yy3ulw" targetRef="Activity_05llwq4" />
+    <bpmn:sequenceFlow id="Flow_15bkrk6" name="trndSevNeed&#10;==outsideHomeCare" sourceRef="Gateway_16cy5xh" targetRef="Activity_04tpysh" />
+    <bpmn:sequenceFlow id="Flow_09uqcye" sourceRef="Activity_16mgbz6" targetRef="Event_0hqgm9w" />
+    <bpmn:sequenceFlow id="Flow_0emq1yg" name="examTime == now" sourceRef="Gateway_16cy5xh" targetRef="Gateway_1gkv1yl" />
+    <bpmn:sequenceFlow id="Flow_0najxqy" name="examTime == now" sourceRef="Gateway_1yy3ulw" targetRef="Gateway_1gkv1yl" />
+    <bpmn:sequenceFlow id="Flow_0mw4npb" name="trndSevNeed == outsideHomeCare" sourceRef="Gateway_1yy3ulw" targetRef="Event_0hqgm9w" />
+    <bpmn:sequenceFlow id="Flow_1evs2n3" name="examTime !=now" sourceRef="Gateway_1gkv1yl" targetRef="Event_0hqgm9w" />
+    <bpmn:sequenceFlow id="Flow_12k9phr" name="examTime == now" sourceRef="Gateway_1gkv1yl" targetRef="Event_1bg3bap" />
+    <bpmn:sequenceFlow id="Flow_0jz2w66" sourceRef="Event_1bg3bap" targetRef="Activity_11icm0p" />
+    <bpmn:endEvent id="Event_0685ddn" name="pt expired">
+      <bpmn:incoming>Flow_0ovofms</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:process id="Process_0qvzd4w" isExecutable="false">
+    <bpmn:startEvent id="Event_1v0tpdm" name="EventName1v">
+      <bpmn:outgoing>Flow_0ybbjby</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0gshog9" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0bi07y1" name="End232">
+      <bpmn:incoming>Flow_0yuat3o</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_19u2yz3" name="06- PDA analyze vitals">
+      <bpmn:documentation>if
+    :: sevNeed == discharge
+    :: else -&gt;
+        if
+        :: true -&gt; trndSevNeed = homeCare
+        :: true -&gt; trndSevNeed = outsideHomeCare
+            if
+            :: true -&gt; alert = yes
+            :: true -&gt; alert = no
+            fi
+        fi
+    fi</bpmn:documentation>
+      <bpmn:incoming>Flow_0ybbjby</bpmn:incoming>
+      <bpmn:outgoing>Flow_0yuat3o</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0ybbjby" sourceRef="Event_1v0tpdm" targetRef="Activity_19u2yz3" />
+    <bpmn:sequenceFlow id="Flow_0yuat3o" sourceRef="Activity_19u2yz3" targetRef="Event_0bi07y1" />
+  </bpmn:process>
+  <bpmn:process id="Process_1flbpwq" isExecutable="false">
+    <bpmn:startEvent id="Event_0mqix7y" name="Start170">
+      <bpmn:outgoing>Flow_06kr7ok</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1c75lp9" />
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_188x4wy" name="04- Pt or care-giver start OTC-Rx as ordered">
+      <bpmn:incoming>Flow_06kr7ok</bpmn:incoming>
+      <bpmn:outgoing>Flow_0m1nh56</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Activity_0pl73xy" name="05- Pt or care-giver measure vitals at instructed times">
+      <bpmn:documentation>if
+    :: trndSevNeed == outsideHomeCare -&gt;
+        sevNeed = expired
+    :: true
+    fi</bpmn:documentation>
+      <bpmn:incoming>Flow_0m1nh56</bpmn:incoming>
+      <bpmn:incoming>Flow_1kexvd1</bpmn:incoming>
+      <bpmn:outgoing>Flow_1253ah4</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="Gateway_1qegca1" name="Xor6 fatality">
+      <bpmn:incoming>Flow_1253ah4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hd21j8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0lzszai</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="Event_05t87v3" name="pt expired1">
+      <bpmn:incoming>Flow_1hd21j8</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_0v75iy6" name="Xor7 examTime = now">
+      <bpmn:incoming>Flow_0lzszai</bpmn:incoming>
+      <bpmn:outgoing>Flow_1kexvd1</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0acak9f</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="Event_07cfz9u" name="End196">
+      <bpmn:incoming>Flow_0t07u0i</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:intermediateThrowEvent id="Event_1qmt0d1" name="seconds throw pt">
+      <bpmn:incoming>Flow_0acak9f</bpmn:incoming>
+      <bpmn:outgoing>Flow_0t07u0i</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_079s4q9" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_06kr7ok" sourceRef="Event_0mqix7y" targetRef="Activity_188x4wy" />
+    <bpmn:sequenceFlow id="Flow_0m1nh56" sourceRef="Activity_188x4wy" targetRef="Activity_0pl73xy" />
+    <bpmn:sequenceFlow id="Flow_1253ah4" sourceRef="Activity_0pl73xy" targetRef="Gateway_1qegca1" />
+    <bpmn:sequenceFlow id="Flow_1hd21j8" name="sevNeed == expired" sourceRef="Gateway_1qegca1" targetRef="Event_05t87v3" />
+    <bpmn:sequenceFlow id="Flow_0lzszai" name="sevNeed != expired" sourceRef="Gateway_1qegca1" targetRef="Gateway_0v75iy6" />
+    <bpmn:sequenceFlow id="Flow_1kexvd1" name="examTime != now" sourceRef="Gateway_0v75iy6" targetRef="Activity_0pl73xy" />
+    <bpmn:sequenceFlow id="Flow_0acak9f" name="examTime == now" sourceRef="Gateway_0v75iy6" targetRef="Event_1qmt0d1" />
+    <bpmn:sequenceFlow id="Flow_0t07u0i" sourceRef="Event_1qmt0d1" targetRef="Event_07cfz9u" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cy17wr">
+      <bpmndi:BPMNShape id="Participant_0kylnmw_di" bpmnElement="Participant_0kylnmw" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="1150" height="530" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1ix971p">
+        <dc:Bounds x="252" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="235" y="213" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11icm0p_di" bpmnElement="Activity_11icm0p">
+        <dc:Bounds x="280" y="310" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_12crsx7_di" bpmnElement="Gateway_12crsx7" isMarkerVisible="true">
+        <dc:Bounds x="405" y="325" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="400" y="363" width="59" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16mgbz6_di" bpmnElement="Activity_16mgbz6">
+        <dc:Bounds x="340" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1eqejkq_di" bpmnElement="Event_1eqejkq">
+        <dc:Bounds x="582" y="332" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="567" y="375" width="67" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08q4ls8_di" bpmnElement="Event_0hqgm9w">
+        <dc:Bounds x="752" y="331" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="737" y="374" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1s4qrvx_di" bpmnElement="Gateway_1s4qrvx" isMarkerVisible="true">
+        <dc:Bounds x="835" y="324" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="895" y="342" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1f3c6ct_di" bpmnElement="Activity_1f3c6ct">
+        <dc:Bounds x="830" y="480" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_16cy5xh_di" bpmnElement="Gateway_16cy5xh" isMarkerVisible="true">
+        <dc:Bounds x="985" y="495" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="981" y="552" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05llwq4_di" bpmnElement="Activity_05llwq4">
+        <dc:Bounds x="1090" y="480" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1gkv1yl_di" bpmnElement="Gateway_1gkv1yl" isMarkerVisible="true">
+        <dc:Bounds x="1235" y="365" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1161" y="373.5" width="77" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pmtxeh_di" bpmnElement="Activity_0pmtxeh">
+        <dc:Bounds x="840" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1yy3ulw_di" bpmnElement="Gateway_1yy3ulw" isMarkerVisible="true">
+        <dc:Bounds x="985" y="225" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="984" y="186" width="53" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0l0nbsa_di" bpmnElement="Event_0l0nbsa">
+        <dc:Bounds x="442" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="424" y="205" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15twws8_di" bpmnElement="Activity_15twws8">
+        <dc:Bounds x="500" y="240" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_169v3vp_di" bpmnElement="Gateway_169v3vp" isMarkerVisible="true">
+        <dc:Bounds x="525" y="155" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="520" y="123" width="59" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_070t4bq_di" bpmnElement="Event_1bg3bap">
+        <dc:Bounds x="282" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="265" y="145" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_04tpysh_di" bpmnElement="Activity_04tpysh">
+        <dc:Bounds x="1130" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0685ddn_di" bpmnElement="Event_0685ddn">
+        <dc:Bounds x="622" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="616" y="205" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0l518mv_di" bpmnElement="Flow_0l518mv">
+        <di:waypoint x="279" y="265" />
+        <di:waypoint x="306" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vil2qp_di" bpmnElement="Flow_1vil2qp">
+        <di:waypoint x="380" y="350" />
+        <di:waypoint x="405" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i2f31g_di" bpmnElement="Flow_1i2f31g">
+        <di:waypoint x="430" y="325" />
+        <di:waypoint x="430" y="280" />
+        <di:waypoint x="500" y="280" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="386" y="240" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1byrxyc_di" bpmnElement="Flow_1byrxyc">
+        <di:waypoint x="430" y="375" />
+        <di:waypoint x="430" y="408" />
+        <di:waypoint x="390" y="408" />
+        <di:waypoint x="390" y="440" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="429" y="396" width="62" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1aatpfx_di" bpmnElement="Flow_1aatpfx">
+        <di:waypoint x="455" y="350" />
+        <di:waypoint x="582" y="350" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="356" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0if4pkb_di" bpmnElement="Flow_0if4pkb">
+        <di:waypoint x="550" y="240" />
+        <di:waypoint x="550" y="205" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ovofms_di" bpmnElement="Flow_0ovofms">
+        <di:waypoint x="575" y="180" />
+        <di:waypoint x="622" y="180" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="569" y="146" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00vh7e4_di" bpmnElement="Flow_00vh7e4">
+        <di:waypoint x="525" y="180" />
+        <di:waypoint x="478" y="180" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="472" y="146" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18hg8nu_di" bpmnElement="Flow_18hg8nu">
+        <di:waypoint x="788" y="349" />
+        <di:waypoint x="835" y="349" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1arg57d_di" bpmnElement="Flow_1arg57d">
+        <di:waypoint x="860" y="324" />
+        <di:waypoint x="860" y="302" />
+        <di:waypoint x="890" y="302" />
+        <di:waypoint x="890" y="280" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="821" y="284" width="58" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mq8ktv_di" bpmnElement="Flow_0mq8ktv">
+        <di:waypoint x="860" y="374" />
+        <di:waypoint x="860" y="398" />
+        <di:waypoint x="880" y="420" />
+        <di:waypoint x="880" y="480" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="883" y="402" width="53" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09z1r76_di" bpmnElement="Flow_09z1r76">
+        <di:waypoint x="930" y="520" />
+        <di:waypoint x="985" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n35392_di" bpmnElement="Flow_0n35392">
+        <di:waypoint x="997" y="532" />
+        <di:waypoint x="930" y="580" />
+        <di:waypoint x="730" y="580" />
+        <di:waypoint x="730" y="349" />
+        <di:waypoint x="752" y="349" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="736" y="540" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rfqfky_di" bpmnElement="Flow_1rfqfky">
+        <di:waypoint x="1035" y="520" />
+        <di:waypoint x="1090" y="520" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1020" y="480" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0q85pgz_di" bpmnElement="Flow_0q85pgz">
+        <di:waypoint x="1180" y="480" />
+        <di:waypoint x="1249" y="404" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1191" y="461" width="49" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wumukp_di" bpmnElement="Flow_0wumukp">
+        <di:waypoint x="940" y="240" />
+        <di:waypoint x="963" y="240" />
+        <di:waypoint x="963" y="250" />
+        <di:waypoint x="985" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ugiucz_di" bpmnElement="Flow_0ugiucz">
+        <di:waypoint x="1035" y="250" />
+        <di:waypoint x="1130" y="250" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1040" y="210" width="86" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jccwa3_di" bpmnElement="Flow_0jccwa3">
+        <di:waypoint x="1200" y="290" />
+        <di:waypoint x="1250" y="375" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1205" y="296" width="49" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_189nm76_di" bpmnElement="Flow_189nm76">
+        <di:waypoint x="1019" y="266" />
+        <di:waypoint x="1132" y="480" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="966" y="329" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15bkrk6_di" bpmnElement="Flow_15bkrk6">
+        <di:waypoint x="1020" y="505" />
+        <di:waypoint x="1173" y="290" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1067" y="316" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09uqcye_di" bpmnElement="Flow_09uqcye">
+        <di:waypoint x="440" y="480" />
+        <di:waypoint x="670" y="480" />
+        <di:waypoint x="670" y="349" />
+        <di:waypoint x="752" y="349" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0emq1yg_di" bpmnElement="Flow_0emq1yg">
+        <di:waypoint x="1021" y="534" />
+        <di:waypoint x="1060" y="580" />
+        <di:waypoint x="1260" y="580" />
+        <di:waypoint x="1260" y="415" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1125" y="562" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0najxqy_di" bpmnElement="Flow_0najxqy">
+        <di:waypoint x="1020" y="235" />
+        <di:waypoint x="1060" y="180" />
+        <di:waypoint x="1260" y="180" />
+        <di:waypoint x="1260" y="365" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1105" y="162" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mw4npb_di" bpmnElement="Flow_0mw4npb">
+        <di:waypoint x="1000" y="235" />
+        <di:waypoint x="960" y="180" />
+        <di:waypoint x="730" y="180" />
+        <di:waypoint x="730" y="349" />
+        <di:waypoint x="752" y="349" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="788" y="155" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1evs2n3_di" bpmnElement="Flow_1evs2n3">
+        <di:waypoint x="1280" y="385" />
+        <di:waypoint x="1280" y="150" />
+        <di:waypoint x="670" y="150" />
+        <di:waypoint x="670" y="350" />
+        <di:waypoint x="752" y="349" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1069" y="132" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12k9phr_di" bpmnElement="Flow_12k9phr">
+        <di:waypoint x="1285" y="390" />
+        <di:waypoint x="1300" y="390" />
+        <di:waypoint x="1300" y="120" />
+        <di:waypoint x="318" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="905" y="103" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jz2w66_di" bpmnElement="Flow_0jz2w66">
+        <di:waypoint x="303" y="137" />
+        <di:waypoint x="327" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_1b7yqru_di" bpmnElement="Participant_1b7yqru" isHorizontal="true">
+        <dc:Bounds x="160" y="620" width="1150" height="120" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0wvknhb_di" bpmnElement="Event_1v0tpdm">
+        <dc:Bounds x="592" y="652" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="577" y="633" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0bi07y1_di" bpmnElement="Event_0bi07y1">
+        <dc:Bounds x="812" y="652" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="812" y="695" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_19u2yz3_di" bpmnElement="Activity_19u2yz3">
+        <dc:Bounds x="660" y="640" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ybbjby_di" bpmnElement="Flow_0ybbjby">
+        <di:waypoint x="628" y="670" />
+        <di:waypoint x="660" y="670" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yuat3o_di" bpmnElement="Flow_0yuat3o">
+        <di:waypoint x="760" y="670" />
+        <di:waypoint x="812" y="670" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0zelsdj_di" bpmnElement="Participant_0zelsdj" isHorizontal="true">
+        <dc:Bounds x="160" y="750" width="1150" height="255" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0o768ye_di" bpmnElement="Event_0mqix7y">
+        <dc:Bounds x="332" y="792" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="329" y="835" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_188x4wy_di" bpmnElement="Activity_188x4wy">
+        <dc:Bounds x="420" y="770" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pl73xy_di" bpmnElement="Activity_0pl73xy">
+        <dc:Bounds x="560" y="770" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1qegca1_di" bpmnElement="Gateway_1qegca1" isMarkerVisible="true">
+        <dc:Bounds x="695" y="785" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="690" y="761" width="59" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05t87v3_di" bpmnElement="Event_05t87v3">
+        <dc:Bounds x="862" y="792" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="853" y="835" width="55" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0v75iy6_di" bpmnElement="Gateway_0v75iy6" isMarkerVisible="true">
+        <dc:Bounds x="585" y="895" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="568" y="952" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07cfz9u_di" bpmnElement="Event_07cfz9u">
+        <dc:Bounds x="242" y="872" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="242" y="915" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0076uhl_di" bpmnElement="Event_1qmt0d1">
+        <dc:Bounds x="302" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="277" y="945" width="87" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_06kr7ok_di" bpmnElement="Flow_06kr7ok">
+        <di:waypoint x="368" y="810" />
+        <di:waypoint x="420" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m1nh56_di" bpmnElement="Flow_0m1nh56">
+        <di:waypoint x="520" y="810" />
+        <di:waypoint x="560" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1253ah4_di" bpmnElement="Flow_1253ah4">
+        <di:waypoint x="660" y="810" />
+        <di:waypoint x="695" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hd21j8_di" bpmnElement="Flow_1hd21j8">
+        <di:waypoint x="745" y="810" />
+        <di:waypoint x="862" y="810" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="774" y="786" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lzszai_di" bpmnElement="Flow_0lzszai">
+        <di:waypoint x="720" y="835" />
+        <di:waypoint x="720" y="920" />
+        <di:waypoint x="635" y="920" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="722" y="875" width="55" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1kexvd1_di" bpmnElement="Flow_1kexvd1">
+        <di:waypoint x="610" y="895" />
+        <di:waypoint x="610" y="850" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="583" y="870" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0acak9f_di" bpmnElement="Flow_0acak9f">
+        <di:waypoint x="585" y="920" />
+        <di:waypoint x="338" y="920" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="417" y="902" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0t07u0i_di" bpmnElement="Flow_0t07u0i">
+        <di:waypoint x="302" y="920" />
+        <di:waypoint x="290" y="920" />
+        <di:waypoint x="290" y="890" />
+        <di:waypoint x="278" y="890" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gy5dgg_di" bpmnElement="Flow_0gy5dgg">
+        <di:waypoint x="320" y="902" />
+        <di:waypoint x="320" y="475" />
+        <di:waypoint x="210" y="475" />
+        <di:waypoint x="210" y="120" />
+        <di:waypoint x="282" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0so3xgl_di" bpmnElement="Flow_0so3xgl">
+        <di:waypoint x="350" y="520" />
+        <di:waypoint x="350" y="792" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rcqwgc_di" bpmnElement="Flow_0rcqwgc">
+        <di:waypoint x="610" y="770" />
+        <di:waypoint x="610" y="688" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15qty2a_di" bpmnElement="Flow_15qty2a">
+        <di:waypoint x="710" y="640" />
+        <di:waypoint x="710" y="349" />
+        <di:waypoint x="752" y="349" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -13,6 +13,7 @@ from returns.unsafe import unsafe_perform_io
 
 from bpmncwpverify.cli import _trigger_lambda, cli_verify, verify, web_verify
 from bpmncwpverify.core.error import (
+    BpmnNoSwimLaneNameError,
     Error,
     FileReadFileError,
     HttpError,
@@ -99,13 +100,33 @@ def test_givin_bad_state_file_when_verify_then_state_errror(capsys):
 
 
 @pytest.mark.skipif(os.getenv("CI") == "true", reason="No SPIN on GitHub CI/CD")
-def test_givin_good_files_when_verify_then_success(capsys):
+def test_givin_bad_files_when_verify_then_faliure(capsys):
     # given
     test_args = [
         "verify",
         "./test/resources/simple_example/state.txt",
         "./test/resources/simple_example/test_cwp.xml",
         "./test/resources/simple_example/test_bpmn.bpmn",
+    ]
+    sys.argv = test_args
+
+    # when
+    result = cli_verify(test_args[1], test_args[2], test_args[3])
+
+    # then
+    assert not_(is_successful(result))
+    error = unsafe_perform_io(result.failure())
+    assert isinstance(error, BpmnNoSwimLaneNameError)
+
+
+@pytest.mark.skipif(os.getenv("CI") == "true", reason="No SPIN on GitHub CI/CD")
+def test_givin_good_files_when_verify_then_success(capsys):
+    # given
+    test_args = [
+        "verify",
+        "./test/resources/face2face/state.txt",
+        "./test/resources/face2face/cwp.xml",
+        "./test/resources/face2face/workflow.bpmn",
     ]
     sys.argv = test_args
 
@@ -120,7 +141,7 @@ def test_givin_good_files_when_verify_then_success(capsys):
 
 
 @pytest.mark.skipif(os.getenv("CI") == "true", reason="No SPIN on GitHub CI/CD")
-def test_given_good_input_when_webverify_then_success():
+def test_given_bad_input_when_webverify_then_faliure():
     # given
     bpmn = ""
     with open("./test/resources/simple_example/test_bpmn.bpmn") as bpmn_file:
@@ -134,6 +155,33 @@ def test_given_good_input_when_webverify_then_success():
 
     state = ""
     with open("./test/resources/simple_example/state.txt") as state_file:
+        for line in state_file:
+            state += line
+
+    # when
+    result = web_verify(state, cwp, bpmn)
+
+    # then
+    assert not_(is_successful(result))
+    error = unsafe_perform_io(result.failure())
+    assert isinstance(error, BpmnNoSwimLaneNameError)
+
+
+@pytest.mark.skipif(os.getenv("CI") == "true", reason="No SPIN on GitHub CI/CD")
+def test_given_good_input_when_webverify_then_success():
+    # given
+    bpmn = ""
+    with open("./test/resources/face2face/workflow.bpmn") as bpmn_file:
+        for line in bpmn_file:
+            bpmn += line
+
+    cwp = ""
+    with open("./test/resources/face2face/cwp.xml") as cwp_file:
+        for line in cwp_file:
+            cwp += line
+
+    state = ""
+    with open("./test/resources/face2face/state.txt") as state_file:
         for line in state_file:
             state += line
 

--- a/test/visitors/bpmnchecks/test_bpmnvalidate.py
+++ b/test/visitors/bpmnchecks/test_bpmnvalidate.py
@@ -1,7 +1,11 @@
 # type: ignore
 import pytest
 
-from bpmncwpverify.core.error import BpmnMsgFlowSamePoolError
+from bpmncwpverify.core.error import (
+    BpmnMsgFlowSamePoolError,
+    BpmnNoElementNameError,
+    BpmnNoSwimLaneNameError,
+)
 from bpmncwpverify.visitors.bpmnchecks.bpmnvalidate import validate_bpmn
 
 
@@ -18,6 +22,8 @@ def setup_bpmn(mocker):
     process2.all_items.return_value = ["node3", "node4"]
 
     bpmn.processes = {"process1": process1, "process2": process2}
+
+    bpmn.id_to_element = {}
 
     msg1 = mocker.MagicMock()
     msg1.id = "msg1"
@@ -50,3 +56,27 @@ def test_validate_bpmn_msg_same_pool_error(mocker, setup_bpmn):
     # Check the exception type and message
     assert isinstance(result.failure(), BpmnMsgFlowSamePoolError)
     assert result.failure().msg_id == "msg2"
+
+
+def test_validate_bpmn_no_name_error(mocker, setup_bpmn):
+    bpmn = setup_bpmn
+
+    mock_element = mocker.MagicMock()
+    mock_element.id = "Event_id"
+    mock_element.name = "Event_id"
+
+    bpmn.id_to_element["Event_id"] = mock_element
+
+    result = validate_bpmn(bpmn)
+
+    assert isinstance(result.failure(), BpmnNoElementNameError)
+
+
+def test_validate_bpmn_no_swimlane_error(mocker, setup_bpmn):
+    bpmn = setup_bpmn
+    bpmn.processes["process1"].name = "Process1"
+    bpmn.processes["process1"].id = "Process1"
+
+    result = validate_bpmn(bpmn)
+
+    assert isinstance(result.failure(), BpmnNoSwimLaneNameError)

--- a/test/visitors/test_bpmn_promela_visitor.py
+++ b/test/visitors/test_bpmn_promela_visitor.py
@@ -462,7 +462,10 @@ def test_build_expr_conditional(promela_visitor, mocker):
             mocker.call("if", NL_SINGLE),
             mocker.call(":: EXPR1==test_val -> putToken(TEST2_FROM_TEST1)", NL_SINGLE),
             mocker.call(":: EXPR2 -> putToken(TEST3_FROM_TEST1)", NL_SINGLE),
-            mocker.call(":: atomic{else -> assert false}", NL_SINGLE),
+            mocker.call(
+                ':: atomic{else -> printf("Assert: No viable path to take"); assert false}',
+                NL_SINGLE,
+            ),
             mocker.call("fi", NL_SINGLE),
         ]
     )
@@ -506,7 +509,10 @@ def test_build_conditional_with_boundary_event(promela_visitor, mocker):
             mocker.call("consumeToken(TEST2)", NL_SINGLE),
             mocker.call("putToken(2TSET)", NL_SINGLE),
             mocker.call("", indent_action=IndentAction.DEC),
-            mocker.call(":: atomic{else -> assert false}", 1),
+            mocker.call(
+                ':: atomic{else -> printf("Assert: No viable path to take"); assert false}',
+                1,
+            ),
             mocker.call("fi", NL_SINGLE),
         ]
     )


### PR DESCRIPTION
The counter example was refactored and fixed to get initState variables, the issue, and the steps that led to it. The counterexample was pulled from SpinSyntaxErrors and SpinCoverageErrors. Enforced Swimlanes and names for all events, gateways, and activities. And promela generation was changed to fix else asserts with a print statement and a state_dumper for init values. All tests were fixed to accommodate these changes