### PR TITLE
Added printf statements before all assers in pml

### DIFF
--- a/src/bpmncwpverify/core/spin.py
+++ b/src/bpmncwpverify/core/spin.py
@@ -189,7 +189,7 @@ class SpinOutputParser:
 
         # Regular expression to match line information
         line_pattern = re.compile(
-            r"(?P<file>[\w\.]+):(?P<line>\d+), state \d+, (?P<message>\"(?!.*assert).*?\")"
+            r"(?P<file>[\w\.]+):(?P<line>\d+), state \d+, (?P<message>\"(?!.*Assert).*?\")"
         )
 
         # Find all relevant blocks (excluding never claims)

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -17,7 +17,7 @@ from bpmncwpverify.util.stringmanager import IndentAction, StringManager
 ##############
 # Constants
 ##############
-HELPER_FUNCS_STR = "#define hasToken(place) (place != 0)\n\ninline putToken(place) {\n\tassert (place != 1)\n\tplace = 1\n}\n\n#define consumeToken(place) place = 0\n"
+HELPER_FUNCS_STR = '#define hasToken(place) (place != 0)\n\ninline putToken(place) {\n\tif\n\t\t:: place != 1 -> place = 1\n\t\t:: else -> {\n\t\t\tprintf("Assert: Attempting to place token in already-occupied place\\n")\n\t\t\tassert false\n\t\t}\n\tfi\n}\n\n#define consumeToken(place) place = 0\n'
 NL_NONE = 0
 NL_SINGLE = 1
 NL_DOUBLE = 2

--- a/src/bpmncwpverify/visitors/cwp_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/cwp_promela_visitor.py
@@ -103,7 +103,10 @@ class CwpPromelaVisitor(CwpVisitor):
 
         nWayXor.write_str("if", NL_SINGLE, IndentAction.INC)
 
-        nWayXor.write_str(":: (sumOfActiveStates != 1) -> assert false", NL_SINGLE)
+        nWayXor.write_str(
+            ':: (sumOfActiveStates != 1) -> {printf("Assert: In more that one or no state"); assert false}',
+            NL_SINGLE,
+        )
         nWayXor.write_str(":: else -> skip", NL_SINGLE)
 
         nWayXor.write_str("fi", NL_SINGLE, IndentAction.DEC)
@@ -146,7 +149,10 @@ class CwpPromelaVisitor(CwpVisitor):
 
         self.update_state_inline.write_str(self.proper_path_block)
 
-        self.update_state_inline.write_str(":: else -> assert false", NL_SINGLE)
+        self.update_state_inline.write_str(
+            ':: else -> printf("Assert: Not a valid CWP transition"); assert false',
+            NL_SINGLE,
+        )
 
         self.update_state_inline.write_str("fi", NL_SINGLE, IndentAction.DEC)
 

--- a/test/visitors/test_cwp_promela_visitor.py
+++ b/test/visitors/test_cwp_promela_visitor.py
@@ -43,7 +43,10 @@ class TestCwpPromelaVisitor:
             mocker.call(prime_vars),
             mocker.call("if", NL_SINGLE, IndentAction.INC),
             mocker.call(proper_path_block),
-            mocker.call(":: else -> assert false", NL_SINGLE),
+            mocker.call(
+                ':: else -> printf("Assert: Not a valid CWP transition"); assert false',
+                NL_SINGLE,
+            ),
             mocker.call("fi", NL_SINGLE, IndentAction.DEC),
             mocker.call(var_reassignment),
             mocker.call("test_val"),
@@ -164,7 +167,10 @@ class TestCwpPromelaVisitor:
             mocker.call("int sumOfActiveStates = "),
             mocker.call("state1 + state2 + state3", NL_DOUBLE),
             mocker.call("if", NL_SINGLE, IndentAction.INC),
-            mocker.call(":: (sumOfActiveStates != 1) -> assert false", NL_SINGLE),
+            mocker.call(
+                ':: (sumOfActiveStates != 1) -> {printf("Assert: In more that one or no state"); assert false}',
+                NL_SINGLE,
+            ),
             mocker.call(":: else -> skip", NL_SINGLE),
             mocker.call("fi", NL_SINGLE, IndentAction.DEC),
         ]


### PR DESCRIPTION
Every assert in the Promela will have a print statement, so that if an assert is thrown, the counterexample can match on it and provide more information.
Adjusted the test to match the new output
Adjusted check_coverage_errors in spin.py to ignore the printf for those paths

will close 339