### PR TITLE
Error catch

### DIFF
--- a/src/bpmncwpverify/core/accessmethods/cwpmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/cwpmethods.py
@@ -44,7 +44,7 @@ class CwpXmlParser:
         for element in states:
             style = element.get("style")
             if style and "edgeLabel" not in style:
-                if "rounded=1" not in style:
+                if "rounded=1" not in style and "rounded=0" not in style:
                     unsupported_shapes += 1
                 state = CwpState.from_xml(element)
                 builder = builder.with_state(state)
@@ -52,7 +52,7 @@ class CwpXmlParser:
         if unsupported_shapes != 0:
             raise Exception(
                 CwpUnsupportedElementError(
-                    unsupported_shapes, "different shapes other than rounded rectangles"
+                    unsupported_shapes, "different shapes other than rectangles"
                 )
             )
 

--- a/src/bpmncwpverify/core/accessmethods/cwpmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/cwpmethods.py
@@ -8,6 +8,7 @@ from bpmncwpverify.core.error import (
     CwpEdgeNoParentExprError,
     CwpEdgeNoStateError,
     CwpFileStructureError,
+    CwpUnsupportedElementError,
     Error,
 )
 from bpmncwpverify.core.expr import ExpressionListener
@@ -25,6 +26,8 @@ class CwpXmlParser:
             raise Exception(CwpFileStructureError("root"))
         if not (mx_cells := mx_root.findall("mxCell")):
             raise Exception(CwpFileStructureError("mxCell"))
+        if object := mx_root.findall("object"):
+            raise Exception(CwpUnsupportedElementError(len(object), "object"))
         return mx_cells
 
     def _get_all_items(self, mx_cells: list[Element]) -> list[Element]:

--- a/src/bpmncwpverify/core/accessmethods/cwpmethods.py
+++ b/src/bpmncwpverify/core/accessmethods/cwpmethods.py
@@ -40,11 +40,21 @@ class CwpXmlParser:
         return [itm for itm in mx_cells if itm.get("vertex")]
 
     def _add_states(self, builder: CwpBuilder, states: list[Element]) -> None:
+        unsupported_shapes: int = 0
         for element in states:
             style = element.get("style")
             if style and "edgeLabel" not in style:
+                if "rounded=1" not in style:
+                    unsupported_shapes += 1
                 state = CwpState.from_xml(element)
                 builder = builder.with_state(state)
+
+        if unsupported_shapes != 0:
+            raise Exception(
+                CwpUnsupportedElementError(
+                    unsupported_shapes, "different shapes other than rounded rectangles"
+                )
+            )
 
     def _add_edges(self, builder: CwpBuilder, edges: list[Element]) -> None:
         for element in edges:

--- a/src/bpmncwpverify/core/cwp.py
+++ b/src/bpmncwpverify/core/cwp.py
@@ -108,15 +108,16 @@ class CwpEdge:
         CONDITIONALS = ("==", "!=", "<=", "=<", "<", ">", ">=", "=>")
         ALL = OPS + CONDITIONALS
         prev_operation = ""
-        i = 0
+        i = 1
 
         while i != len(s):
             if i == len(s) - 1:
                 break
             elif s[i] in OPS:
                 prev_operation = s[i]
-            elif s[i] not in ALL and s[i + 1] not in ALL:
-                s.insert(i + 1, prev_operation)
+            elif s[i - 1] not in ALL and s[i] not in ALL:
+                s.insert(i, prev_operation)
+                i += 1
             i += 1
 
         return " ".join(s)

--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -671,7 +671,7 @@ def get_error_message(error: Error) -> str:
         case CwpUnsupportedElementError(
             number_of_elements=number_of_elements, element=element
         ):
-            return f"CWP ERROR: {element} is not supported and there exists {number_of_elements}"
+            return f"CWP ERROR: {element} is/are not supported and there exists {number_of_elements}"
         case CwpFileStructureError(element=element):
             return f"A {element} element is missing from your cwp file."
         case CwpGraphConnError():

--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -223,6 +223,15 @@ class CwpEdgeNoStateError(Error):
         self.edge = edge
 
 
+class CwpUnsupportedElementError(Error):
+    __slots__ = ["number_of_elements", "element"]
+
+    def __init__(self, number_of_elements: int, element: str) -> None:
+        super().__init__()
+        self.number_of_elements = number_of_elements
+        self.element = element
+
+
 class CwpFileStructureError(Error):
     __slots__ = ["element"]
 
@@ -659,6 +668,10 @@ def get_error_message(error: Error) -> str:
             return f"CWP ERROR: Expression or parent node not found in edge. Edge details: {edge.attrib}."
         case CwpEdgeNoStateError(edge=edge):
             return f"CWP ERROR: Edge does not have a source or a target. Edge details: {edge.attrib}."
+        case CwpUnsupportedElementError(
+            number_of_elements=number_of_elements, element=element
+        ):
+            return f"CWP ERROR: {element} is not supported and there exists {number_of_elements}"
         case CwpFileStructureError(element=element):
             return f"A {element} element is missing from your cwp file."
         case CwpGraphConnError():

--- a/test/core/accessmethods/test_cwpmethods.py
+++ b/test/core/accessmethods/test_cwpmethods.py
@@ -101,7 +101,7 @@ class TestCwpXmlParser:
         states = []
         for _ in range(3):
             mock_state = mocker.Mock()
-            mock_state.get.return_value = "test"
+            mock_state.get.return_value = "rounded=1;test"
             states.append(mock_state)
 
         mock_builder = mocker.Mock()
@@ -115,6 +115,26 @@ class TestCwpXmlParser:
         calls = [mocker.call("test_state") for _ in range(3)]
         mock_builder.with_state.assert_has_calls(calls)
         mock_from_xml.assert_has_calls([mocker.call(state) for state in states])
+
+    def test_add_states_not_rounded_rectangles(self, mocker):
+        states = []
+        for _ in range(3):
+            mock_state = mocker.Mock()
+            mock_state.get.return_value = "rounded=0;test"
+            states.append(mock_state)
+
+        mock_builder = mocker.Mock()
+        mock_builder.with_state.return_value = mock_builder
+
+        with pytest.raises(Exception) as exc_info:
+            CwpXmlParser._add_states(mocker.Mock(), mock_builder, states)
+
+        assert isinstance(exc_info.value.args[0], CwpUnsupportedElementError)
+        assert (
+            exc_info.value.args[0].element
+            == "different shapes other than rounded rectangles"
+        )
+        assert exc_info.value.args[0].number_of_elements == 3
 
     def test_add_edges_no_src_or_target(self, mocker):
         mock_edge = mocker.Mock()

--- a/test/core/accessmethods/test_cwpmethods.py
+++ b/test/core/accessmethods/test_cwpmethods.py
@@ -8,6 +8,7 @@ from bpmncwpverify.core.error import (
     CwpEdgeNoParentExprError,
     CwpEdgeNoStateError,
     CwpFileStructureError,
+    CwpUnsupportedElementError,
 )
 
 
@@ -20,9 +21,29 @@ class TestCwpXmlParser:
         mx_cells = mocker.Mock()
         root.find.return_value = diagram
         diagram.find.return_value = mx_graph_model
-        mx_root.findall.return_value = mx_cells
+        mx_graph_model.find.return_value = mx_root
+        mx_root.findall.side_effect = lambda x: mx_cells if x == "mxCell" else {}
         CwpXmlParser._get_mx_cells(mocker.Mock(), root)
         # should not throw error
+
+    def test_get_xml_cells_fail(self, mocker):
+        root = mocker.Mock()
+        diagram = mocker.Mock()
+        mx_graph_model = mocker.Mock()
+        mx_root = mocker.Mock()
+        mx_cells = mocker.Mock()
+        object = [mocker.Mock()]
+        root.find.return_value = diagram
+
+        diagram.find.return_value = mx_graph_model
+        mx_graph_model.find.return_value = mx_root
+        mx_root.findall.side_effect = lambda x: mx_cells if x == "mxCell" else object
+
+        with pytest.raises(Exception) as exc_info:
+            CwpXmlParser._get_mx_cells(mocker.Mock(), root)
+
+        assert isinstance(exc_info.value.args[0], CwpUnsupportedElementError)
+        assert exc_info.value.args[0].element == "object"
 
     def test_get_xml_cells_no_diagram(self, mocker):
         root = mocker.Mock()

--- a/test/core/accessmethods/test_cwpmethods.py
+++ b/test/core/accessmethods/test_cwpmethods.py
@@ -116,11 +116,11 @@ class TestCwpXmlParser:
         mock_builder.with_state.assert_has_calls(calls)
         mock_from_xml.assert_has_calls([mocker.call(state) for state in states])
 
-    def test_add_states_not_rounded_rectangles(self, mocker):
+    def test_add_states_not_rectangles(self, mocker):
         states = []
         for _ in range(3):
             mock_state = mocker.Mock()
-            mock_state.get.return_value = "rounded=0;test"
+            mock_state.get.return_value = "ellipse;test"
             states.append(mock_state)
 
         mock_builder = mocker.Mock()
@@ -131,8 +131,7 @@ class TestCwpXmlParser:
 
         assert isinstance(exc_info.value.args[0], CwpUnsupportedElementError)
         assert (
-            exc_info.value.args[0].element
-            == "different shapes other than rounded rectangles"
+            exc_info.value.args[0].element == "different shapes other than rectangles"
         )
         assert exc_info.value.args[0].number_of_elements == 3
 

--- a/test/core/test_cwp.py
+++ b/test/core/test_cwp.py
@@ -53,8 +53,8 @@ def test_valid_cwp_end_start_events():
     state = build_state("var x: int = 0")
     root, mx_root = get_root_mx_root()
 
-    add_mx_cell(mx_root, id="s1", value="Start", style="state", vertex="1")
-    add_mx_cell(mx_root, id="s2", value="End", style="state", vertex="1")
+    add_mx_cell(mx_root, id="s1", value="Start", style="rounded=1;state", vertex="1")
+    add_mx_cell(mx_root, id="s2", value="End", style="rounded=1;state", vertex="1")
     add_mx_cell(mx_root, id="e1", source="s1", target="s2", style="edge", edge="1")
     add_mx_cell(
         mx_root, id="expr1", value="x > 0", style="edgeLabel", parent="e1", vertex="1"
@@ -74,7 +74,7 @@ def test_invalid_cwp_missing_start_event():
     state = build_state("var x: int = 0")
     root, mx_root = get_root_mx_root()
 
-    add_mx_cell(mx_root, id="s1", value="state", style="state", vertex="1")
+    add_mx_cell(mx_root, id="s1", value="state", style="rounded=1;state", vertex="1")
 
     setup_cwp_and_assert(
         root, state, success=False, failure_message=CwpNoStartStateError
@@ -86,16 +86,16 @@ def test_invalid_cwp_not_connected():
     root, mx_root = get_root_mx_root()
 
     # First disconnected component
-    add_mx_cell(mx_root, id="s1", value="Start", style="state", vertex="1")
-    add_mx_cell(mx_root, id="s2", value="End", style="state", vertex="1")
+    add_mx_cell(mx_root, id="s1", value="Start", style="rounded=1;state", vertex="1")
+    add_mx_cell(mx_root, id="s2", value="End", style="rounded=1;state", vertex="1")
     add_mx_cell(mx_root, id="e1", source="s1", target="s2", style="edge", edge="1")
     add_mx_cell(
         mx_root, id="expr1", value="x > 0", style="edgeLabel", parent="e1", vertex="1"
     )
 
     # Second disconnected component
-    add_mx_cell(mx_root, id="s3", value="Start", style="state", vertex="1")
-    add_mx_cell(mx_root, id="s4", value="End", style="state", vertex="1")
+    add_mx_cell(mx_root, id="s3", value="Start", style="rounded=1;state", vertex="1")
+    add_mx_cell(mx_root, id="s4", value="End", style="rounded=1;state", vertex="1")
     add_mx_cell(mx_root, id="e2", source="s3", target="s4", style="edge", edge="1")
     add_mx_cell(
         mx_root, id="expr1", value="x > 0", style="edgeLabel", parent="e2", vertex="1"
@@ -113,9 +113,9 @@ def test_invalid_cwp_no_end_state():
     state = build_state("var x: int = 0")
     root, mx_root = get_root_mx_root()
 
-    add_mx_cell(mx_root, id="s1", value="Start", style="state", vertex="1")
-    add_mx_cell(mx_root, id="s2", value="middle1", style="state", vertex="1")
-    add_mx_cell(mx_root, id="s3", value="middle2", style="state", vertex="1")
+    add_mx_cell(mx_root, id="s1", value="Start", style="rounded=1;state", vertex="1")
+    add_mx_cell(mx_root, id="s2", value="middle1", style="rounded=1;state", vertex="1")
+    add_mx_cell(mx_root, id="s3", value="middle2", style="rounded=1;state", vertex="1")
 
     add_mx_cell(mx_root, id="e1", source="s1", target="s2", style="edge", edge="1")
     add_mx_cell(

--- a/test/core/test_error.py
+++ b/test/core/test_error.py
@@ -1,3 +1,4 @@
+# type: ignore
 from unittest import mock
 
 import pytest
@@ -37,6 +38,7 @@ from bpmncwpverify.core.error import (
     CwpNoEndStatesError,
     CwpNoParentEdgeError,
     CwpNoStartStateError,
+    CwpUnsupportedElementError,
     Error,
     ExpressionComputationCompatabilityError,
     ExpressionNegatorError,
@@ -169,6 +171,10 @@ test_inputs: list[tuple[Error, str]] = [
     (
         CwpEdgeNoStateError(mock.Mock(attrib="edge_attrib")),
         "CWP ERROR: Edge does not have a source or a target. Edge details: edge_attrib.",
+    ),
+    (
+        CwpUnsupportedElementError(2, "object"),
+        "CWP ERROR: object is not supported and there exists 2",
     ),
     (
         CwpFileStructureError("element"),
@@ -337,6 +343,7 @@ test_ids: list[str] = [
     "CwpGraphConnError",
     "CwpMultStartStateError",
     "CwpNoEndStatesError",
+    "CwpUnsupportedElementError",
     "CwpNoParentEdgeError",
     "CwpNoStartStateError",
     "ExpressionComputationCompatabilityError",

--- a/test/core/test_error.py
+++ b/test/core/test_error.py
@@ -174,7 +174,7 @@ test_inputs: list[tuple[Error, str]] = [
     ),
     (
         CwpUnsupportedElementError(2, "object"),
-        "CWP ERROR: object is not supported and there exists 2",
+        "CWP ERROR: object is/are not supported and there exists 2",
     ),
     (
         CwpFileStructureError("element"),

--- a/test/resources/blackbox/cwp.xml
+++ b/test/resources/blackbox/cwp.xml
@@ -1,6 +1,6 @@
 <mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36">
   <diagram name="Page-1" id="QPB2AyKY3D_KoL_yY5Al">
-    <mxGraphModel dx="2514" dy="914" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+    <mxGraphModel dx="2276" dy="1231" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />

--- a/test/resources/boundaryevents/cwp.xml
+++ b/test/resources/boundaryevents/cwp.xml
@@ -1,45 +1,45 @@
-
-<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36" version="25.0.3">
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36">
   <diagram name="CWP Diagram" id="0">
-    <mxGraphModel dx="1434" dy="785" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+    <mxGraphModel dx="1355" dy="1169" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="2" value="Start" style="ellipse;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="50" y="150" width="80" height="80" as="geometry" />
+        <mxCell id="3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="Increment_x" vertex="1">
+          <mxGeometry height="80" width="120" x="280" y="300" as="geometry" />
         </mxCell>
-        <mxCell id="3" value="Increment_x" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="200" y="150" width="120" height="80" as="geometry" />
+        <mxCell id="7" edge="1" parent="1" source="3" style="entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" target="TDWvDzlndklMUf2IYcjM-9">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="420" y="340" as="sourcePoint" />
+            <mxPoint x="680" y="340" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="5" value="End" style="ellipse;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="600" y="150" width="80" height="80" as="geometry" />
+        <mxCell id="EdfAfCI1iZDf2Rz-AQtW-11" connectable="0" parent="7" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="x &amp;gt; 5" vertex="1">
+          <mxGeometry relative="1" x="-0.1714" y="2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="6" parent="1" source="2" target="3" edge="1">
+        <mxCell id="EdfAfCI1iZDf2Rz-AQtW-9" edge="1" parent="1" source="3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.25;exitY=0;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;" target="3">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="310" y="210" />
+              <mxPoint x="370" y="210" />
+            </Array>
+            <mxPoint x="380" y="300" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="EdfAfCI1iZDf2Rz-AQtW-10" connectable="0" parent="EdfAfCI1iZDf2Rz-AQtW-9" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="x &amp;lt;= 5" vertex="1">
+          <mxGeometry relative="1" x="0.0533" y="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="TDWvDzlndklMUf2IYcjM-8" edge="1" parent="1" source="TDWvDzlndklMUf2IYcjM-7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="3" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="7" style="entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="3" target="5" edge="1">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="400" y="190" as="targetPoint" />
-          </mxGeometry>
+        <mxCell id="TDWvDzlndklMUf2IYcjM-7" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="Start" vertex="1">
+          <mxGeometry height="60" width="120" x="80" y="310" as="geometry" />
         </mxCell>
-        <mxCell id="EdfAfCI1iZDf2Rz-AQtW-11" value="x &amp;gt; 5" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="7">
-          <mxGeometry x="-0.1714" y="2" relative="1" as="geometry">
-            <mxPoint as="offset" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="EdfAfCI1iZDf2Rz-AQtW-9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.25;exitY=0;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="3" target="3">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="300" y="150" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="230" y="60" />
-              <mxPoint x="290" y="60" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="EdfAfCI1iZDf2Rz-AQtW-10" value="x &amp;lt;= 5" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="EdfAfCI1iZDf2Rz-AQtW-9">
-          <mxGeometry x="0.0533" y="1" relative="1" as="geometry">
-            <mxPoint as="offset" />
-          </mxGeometry>
+        <mxCell id="TDWvDzlndklMUf2IYcjM-9" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="End" vertex="1">
+          <mxGeometry height="60" width="120" x="710" y="310" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/test/resources/phware/cwp.xml
+++ b/test/resources/phware/cwp.xml
@@ -1,123 +1,151 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36" version="26.1.1">
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36">
   <diagram name="Page-1" id="zj0YfL0b-ZGQZwjGIQZH">
-    <mxGraphModel dx="1266" dy="575" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+    <mxGraphModel dx="1355" dy="1169" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-1" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="sMSIsS0hQh0kre_TSsOA-5" target="sMSIsS0hQh0kre_TSsOA-10">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-1" edge="1" parent="1" source="wDgtWifGwwTQPx1ln8rB-6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" target="wDgtWifGwwTQPx1ln8rB-5" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="410" y="190" as="sourcePoint" />
+            <mxPoint x="265" y="250" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-2" value="&lt;div&gt;sevNeed == homeCare &amp;amp;&amp;amp;&lt;/div&gt;&lt;div&gt;trndSevNeed == homeCare&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-1">
-          <mxGeometry x="0.1512" y="-3" relative="1" as="geometry">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-2" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-1" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="&lt;div&gt;sevNeed == homeCare &amp;amp;&amp;amp;&lt;/div&gt;&lt;div&gt;trndSevNeed == homeCare&lt;/div&gt;" vertex="1">
+          <mxGeometry relative="1" x="0.1512" y="-3" as="geometry">
             <mxPoint x="18" y="-17" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="sMSIsS0hQh0kre_TSsOA-5" target="sMSIsS0hQh0kre_TSsOA-15">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-3" edge="1" parent="1" source="wDgtWifGwwTQPx1ln8rB-6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=1;exitY=0.75;exitDx=0;exitDy=0;" target="wDgtWifGwwTQPx1ln8rB-3">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="530" y="200" />
+              <mxPoint x="560" y="200" />
+            </Array>
+            <mxPoint x="530" y="200" as="sourcePoint" />
+            <mxPoint x="560" y="300" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-4" value="sevNeed == outsideHomeCare" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-3">
-          <mxGeometry x="0.2118" y="-4" relative="1" as="geometry">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-4" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-3" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="sevNeed == outsideHomeCare" vertex="1">
+          <mxGeometry relative="1" x="0.2118" y="-4" as="geometry">
             <mxPoint x="17" y="-14" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-5" value="&lt;div&gt;InitState&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="410" y="160" width="120" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="sMSIsS0hQh0kre_TSsOA-10" target="sMSIsS0hQh0kre_TSsOA-22">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-6" edge="1" parent="1" source="wDgtWifGwwTQPx1ln8rB-5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="wDgtWifGwwTQPx1ln8rB-4">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
-              <mxPoint x="230" y="380" />
-              <mxPoint x="230" y="380" />
+              <mxPoint x="265" y="310" />
             </Array>
+            <mxPoint x="265" y="310" as="sourcePoint" />
+            <mxPoint x="230" y="450" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-7" value="&lt;div&gt;sevNeed == homeCare &amp;amp;&amp;amp;&lt;/div&gt;&lt;div&gt;trndSevNeed == outsideHomeCare&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" vertex="1" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-6">
-          <mxGeometry x="0.3286" y="-2" relative="1" as="geometry">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-7" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-6" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" value="&lt;div&gt;sevNeed == homeCare &amp;amp;&amp;amp;&lt;/div&gt;&lt;div&gt;trndSevNeed == outsideHomeCare&lt;/div&gt;" vertex="1">
+          <mxGeometry relative="1" x="0.3286" y="-2" as="geometry">
             <mxPoint x="-18" y="-3" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="sMSIsS0hQh0kre_TSsOA-10" target="sMSIsS0hQh0kre_TSsOA-24">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-8" edge="1" parent="1" source="wDgtWifGwwTQPx1ln8rB-5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" target="wDgtWifGwwTQPx1ln8rB-1">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="110" y="280" />
               <mxPoint x="110" y="630" />
             </Array>
+            <mxPoint x="170" y="280" as="sourcePoint" />
+            <mxPoint x="320" y="630" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-9" value="sevNeed == discharge" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" vertex="1" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-8">
-          <mxGeometry x="0.175" y="-2" relative="1" as="geometry">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-9" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-8" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" value="sevNeed == discharge" vertex="1">
+          <mxGeometry relative="1" x="0.175" y="-2" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-10" value="PtInAppropriateHomeCareState" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="1">
-          <mxGeometry x="170" y="250" width="190" height="60" as="geometry" />
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-11" edge="1" parent="1" source="wDgtWifGwwTQPx1ln8rB-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="wDgtWifGwwTQPx1ln8rB-2">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="560" y="380" as="sourcePoint" />
+            <mxPoint x="500" y="500" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="sMSIsS0hQh0kre_TSsOA-15" target="sMSIsS0hQh0kre_TSsOA-23">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-12" value="sevNeed == expired" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" vertex="1" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-11">
-          <mxGeometry x="-0.21" y="-1" relative="1" as="geometry">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-12" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-11" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" value="sevNeed == expired" vertex="1">
+          <mxGeometry relative="1" x="-0.21" y="-1" as="geometry">
             <mxPoint x="9" y="11" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-13" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="sMSIsS0hQh0kre_TSsOA-15" target="sMSIsS0hQh0kre_TSsOA-24">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-13" edge="1" parent="1" source="wDgtWifGwwTQPx1ln8rB-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" target="wDgtWifGwwTQPx1ln8rB-1">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="680" y="330" />
               <mxPoint x="680" y="630" />
             </Array>
+            <mxPoint x="620" y="330" as="sourcePoint" />
+            <mxPoint x="440" y="630" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-14" value="&lt;div&gt;sevNeed == discharge&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" vertex="1" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-13">
-          <mxGeometry x="-0.35" y="2" relative="1" as="geometry">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-14" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-13" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" value="&lt;div&gt;sevNeed == discharge&lt;/div&gt;" vertex="1">
+          <mxGeometry relative="1" x="-0.35" y="2" as="geometry">
             <mxPoint y="65" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-15" value="&lt;div&gt;hospitalState&lt;/div&gt;" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="1">
-          <mxGeometry x="500" y="300" width="120" height="60" as="geometry" />
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-16" edge="1" parent="1" source="wDgtWifGwwTQPx1ln8rB-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" target="wDgtWifGwwTQPx1ln8rB-3">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="470" y="480" />
+              <mxPoint x="470" y="330" />
+            </Array>
+            <mxPoint x="335" y="480" as="sourcePoint" />
+            <mxPoint x="500" y="330" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="sMSIsS0hQh0kre_TSsOA-22" target="sMSIsS0hQh0kre_TSsOA-15">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-17" value="&lt;div&gt;sevNeed == outsideHomeCare&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" vertex="1" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-16">
-          <mxGeometry x="-0.0635" y="-1" relative="1" as="geometry">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-17" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-16" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" value="&lt;div&gt;sevNeed == outsideHomeCare&lt;/div&gt;" vertex="1">
+          <mxGeometry relative="1" x="-0.0635" y="-1" as="geometry">
             <mxPoint x="1" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-18" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="sMSIsS0hQh0kre_TSsOA-22" target="sMSIsS0hQh0kre_TSsOA-10">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-18" edge="1" parent="1" source="wDgtWifGwwTQPx1ln8rB-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.667;exitY=0.033;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.75;entryY=1;entryDx=0;entryDy=0;" target="wDgtWifGwwTQPx1ln8rB-5">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
-              <mxPoint x="300" y="370" />
-              <mxPoint x="300" y="370" />
+              <mxPoint x="300" y="310" />
             </Array>
+            <mxPoint x="300" y="450" as="sourcePoint" />
+            <mxPoint x="300" y="310" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-19" value="&lt;div&gt;sevNeed == homeCare &amp;amp;&amp;amp;&lt;/div&gt;&lt;div&gt;trndSevNeed == homeCare&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" vertex="1" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-18">
-          <mxGeometry x="0.2143" y="-1" relative="1" as="geometry">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-19" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-18" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" value="&lt;div&gt;sevNeed == homeCare &amp;amp;&amp;amp;&lt;/div&gt;&lt;div&gt;trndSevNeed == homeCare&lt;/div&gt;" vertex="1">
+          <mxGeometry relative="1" x="0.2143" y="-1" as="geometry">
             <mxPoint y="-5" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-20" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="sMSIsS0hQh0kre_TSsOA-22" target="sMSIsS0hQh0kre_TSsOA-23">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-20" edge="1" parent="1" source="wDgtWifGwwTQPx1ln8rB-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=0.392;exitY=0.95;exitDx=0;exitDy=0;exitPerimeter=0;" target="wDgtWifGwwTQPx1ln8rB-2">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
+              <mxPoint x="265" y="507" />
               <mxPoint x="265" y="530" />
             </Array>
+            <mxPoint x="265" y="510" as="sourcePoint" />
+            <mxPoint x="450" y="530" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-21" value="sevNeed == expired" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" vertex="1" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-20">
-          <mxGeometry x="-0.3026" y="-1" relative="1" as="geometry">
+        <mxCell id="sMSIsS0hQh0kre_TSsOA-21" connectable="0" parent="sMSIsS0hQh0kre_TSsOA-20" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBorderColor=none;" value="sevNeed == expired" vertex="1">
+          <mxGeometry relative="1" x="-0.3026" y="-1" as="geometry">
             <mxPoint x="7" y="9" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-22" value="&lt;div&gt;ptInElevatedRiskState&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="195" y="450" width="140" height="60" as="geometry" />
+        <mxCell id="wDgtWifGwwTQPx1ln8rB-1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="ptDischargedState" vertex="1">
+          <mxGeometry height="60" width="120" x="320" y="600" as="geometry" />
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-23" value="&lt;div&gt;ptExpiredState&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="440" y="500" width="120" height="60" as="geometry" />
+        <mxCell id="wDgtWifGwwTQPx1ln8rB-2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="ptExpiredState" vertex="1">
+          <mxGeometry height="60" width="120" x="440" y="500" as="geometry" />
         </mxCell>
-        <mxCell id="sMSIsS0hQh0kre_TSsOA-24" value="&lt;div&gt;ptDischargedState&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="320" y="600" width="120" height="60" as="geometry" />
+        <mxCell id="wDgtWifGwwTQPx1ln8rB-3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="hospitalState" vertex="1">
+          <mxGeometry height="60" width="120" x="500" y="300" as="geometry" />
+        </mxCell>
+        <mxCell id="wDgtWifGwwTQPx1ln8rB-4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="ptInElevatedRiskState" vertex="1">
+          <mxGeometry height="60" width="120" x="220" y="450" as="geometry" />
+        </mxCell>
+        <mxCell id="wDgtWifGwwTQPx1ln8rB-5" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="PtInAppropriateHomeCareState" vertex="1">
+          <mxGeometry height="60" width="180" x="170" y="250" as="geometry" />
+        </mxCell>
+        <mxCell id="wDgtWifGwwTQPx1ln8rB-6" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="InitState" vertex="1">
+          <mxGeometry height="60" width="120" x="410" y="160" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/test/resources/sar/cwp.xml
+++ b/test/resources/sar/cwp.xml
@@ -1,69 +1,55 @@
-<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36" version="29.3.8">
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36">
   <diagram id="gzp6VLMGiPLqydHLWM9W" name="Page-1">
-    <mxGraphModel dx="1426" dy="777" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" background="light-dark(#FFFFFF,#000000)" math="0" shadow="0">
+    <mxGraphModel dx="1355" dy="1169" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" background="light-dark(#FFFFFF,#000000)" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-33" parent="1" style="ellipse;whiteSpace=wrap;html=1;" value="PlanSearch" vertex="1">
-          <mxGeometry height="80" width="120" x="365" y="200" as="geometry" />
-        </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-49" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-31" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-48">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="dWC7u1PsDlPDUTVALTmd-49" edge="1" parent="1" source="zzKEAjI1_oLO3G-XxQyw-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="dWC7u1PsDlPDUTVALTmd-48">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="720" y="280" as="sourcePoint" />
+          </mxGeometry>
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-73" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-49" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(communication == received)" vertex="1">
           <mxGeometry relative="1" x="-0.12" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-31" parent="1" style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;" value="DeployTroops" vertex="1">
-          <mxGeometry height="80" width="120" x="660" y="200" as="geometry" />
-        </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-34" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-32" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-33">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-32" parent="1" style="triangle;whiteSpace=wrap;html=1;align=left;fillColor=default;fillStyle=solid;" value="InitState" vertex="1">
-          <mxGeometry height="130" width="97.5" x="376" y="10" as="geometry" />
-        </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-47" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-33" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-31">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="dWC7u1PsDlPDUTVALTmd-47" edge="1" parent="1" source="zzKEAjI1_oLO3G-XxQyw-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.025;entryY=0.617;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryPerimeter=0;" target="zzKEAjI1_oLO3G-XxQyw-4">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="485" y="240" as="sourcePoint" />
+            <mxPoint x="660" y="240" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-71" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-47" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(risk != both&lt;span style=&quot;background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));&quot;&gt;)&lt;/span&gt;" vertex="1">
           <mxGeometry relative="1" x="-0.2174" y="-1" as="geometry">
             <mxPoint x="17" y="9" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-54" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-33" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-52">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="dWC7u1PsDlPDUTVALTmd-54" edge="1" parent="1" source="zzKEAjI1_oLO3G-XxQyw-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=1;entryY=0.75;entryDx=0;entryDy=0;exitX=0;exitY=0.25;exitDx=0;exitDy=0;" target="zzKEAjI1_oLO3G-XxQyw-1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="365" y="240" as="sourcePoint" />
+            <mxPoint x="197.5" y="240" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-66" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-54" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(risk == both&lt;span style=&quot;background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));&quot;&gt;)&lt;/span&gt;" vertex="1">
           <mxGeometry relative="1" x="0.2179" y="-2" as="geometry">
             <mxPoint x="17" y="2" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-81" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-33" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-32">
+        <mxCell id="dWC7u1PsDlPDUTVALTmd-51" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-48" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="zzKEAjI1_oLO3G-XxQyw-5">
           <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="505" y="212" />
-              <mxPoint x="505" y="75" />
-            </Array>
-            <mxPoint x="480" y="90" as="targetPoint" />
+            <mxPoint x="485" y="460" as="targetPoint" />
           </mxGeometry>
-        </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-82" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-81" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(search == off)" vertex="1">
-          <mxGeometry relative="1" x="0.0992" as="geometry">
-            <mxPoint as="offset" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-51" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-48" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-50">
-          <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-76" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-51" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(conditions == changed)" vertex="1">
           <mxGeometry relative="1" x="0.0514" y="-1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-58" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-48" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-57">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="dWC7u1PsDlPDUTVALTmd-58" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-48" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="zzKEAjI1_oLO3G-XxQyw-6">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="720" y="580" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-72" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-58" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(missingPerson == found)" vertex="1">
           <mxGeometry relative="1" x="-0.2444" y="-1" as="geometry">
@@ -73,22 +59,26 @@
         <mxCell id="dWC7u1PsDlPDUTVALTmd-48" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="ActiveSearch" vertex="1">
           <mxGeometry height="60" width="120" x="660" y="430" as="geometry" />
         </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-62" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-50" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-33">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="dWC7u1PsDlPDUTVALTmd-62" edge="1" parent="1" source="zzKEAjI1_oLO3G-XxQyw-5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.433;entryY=1.067;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;" target="zzKEAjI1_oLO3G-XxQyw-3">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="425" y="420" as="sourcePoint" />
+            <mxPoint x="425" y="280" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-77" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-62" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(communication == received)" vertex="1">
           <mxGeometry relative="1" x="0.0286" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-50" parent="1" style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;" value="UpdateInfo" vertex="1">
-          <mxGeometry height="80" width="120" x="365" y="420" as="geometry" />
-        </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-56" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-52" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-50">
+        <mxCell id="dWC7u1PsDlPDUTVALTmd-56" edge="1" parent="1" source="zzKEAjI1_oLO3G-XxQyw-1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=0.75;exitY=1;exitDx=0;exitDy=0;" target="zzKEAjI1_oLO3G-XxQyw-5">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
+              <mxPoint x="170" y="460" />
               <mxPoint x="160" y="460" />
+              <mxPoint x="160" y="470" />
             </Array>
+            <mxPoint x="160" y="265" as="sourcePoint" />
+            <mxPoint x="365" y="460" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-69" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-56" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(conditions == changed)" vertex="1">
@@ -96,28 +86,25 @@
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-52" parent="1" style="triangle;whiteSpace=wrap;html=1;align=left;" value="NoDeployment" vertex="1">
-          <mxGeometry height="130" width="97.5" x="100" y="175" as="geometry" />
-        </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-60" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-57" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-59">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="dWC7u1PsDlPDUTVALTmd-60" edge="1" parent="1" source="zzKEAjI1_oLO3G-XxQyw-6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="dWC7u1PsDlPDUTVALTmd-59">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="720" y="660" as="sourcePoint" />
+          </mxGeometry>
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-78" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-60" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(communication == received)" vertex="1">
           <mxGeometry relative="1" x="-0.1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-57" parent="1" style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;" value="Missing&lt;span style=&quot;background-color: transparent; color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));&quot;&gt;Person&lt;/span&gt;&lt;span style=&quot;background-color: transparent; color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));&quot;&gt;Located&lt;/span&gt;" vertex="1">
-          <mxGeometry height="80" width="140" x="650" y="580" as="geometry" />
-        </mxCell>
-        <mxCell id="dWC7u1PsDlPDUTVALTmd-61" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-59" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="dWC7u1PsDlPDUTVALTmd-32">
+        <mxCell id="dWC7u1PsDlPDUTVALTmd-61" edge="1" parent="1" source="dWC7u1PsDlPDUTVALTmd-59" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.983;entryY=0.617;entryDx=0;entryDy=0;entryPerimeter=0;" target="zzKEAjI1_oLO3G-XxQyw-2">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="817" y="770" />
               <mxPoint x="817" y="75" />
+              <mxPoint x="468" y="75" />
             </Array>
             <mxPoint x="816.5" y="770" as="sourcePoint" />
-            <mxPoint x="550" y="75" as="targetPoint" />
+            <mxPoint x="473.5" y="75" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-75" connectable="0" parent="dWC7u1PsDlPDUTVALTmd-61" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(search == off)" vertex="1">
@@ -127,6 +114,41 @@
         </mxCell>
         <mxCell id="dWC7u1PsDlPDUTVALTmd-59" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="RetrieveMissing&lt;span style=&quot;background-color: transparent; color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));&quot;&gt;Person&lt;/span&gt;" vertex="1">
           <mxGeometry height="60" width="140" x="650" y="740" as="geometry" />
+        </mxCell>
+        <mxCell id="zzKEAjI1_oLO3G-XxQyw-1" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="&lt;span style=&quot;text-align: left;&quot;&gt;NoDeployment&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="120" x="80" y="200" as="geometry" />
+        </mxCell>
+        <mxCell id="zzKEAjI1_oLO3G-XxQyw-2" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="&lt;span style=&quot;text-align: left;&quot;&gt;InitState&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="120" x="350" y="40" as="geometry" />
+        </mxCell>
+        <mxCell id="zzKEAjI1_oLO3G-XxQyw-3" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="PlanSearch" vertex="1">
+          <mxGeometry height="60" width="120" x="370" y="220" as="geometry" />
+        </mxCell>
+        <mxCell id="zzKEAjI1_oLO3G-XxQyw-4" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="DeployTroops" vertex="1">
+          <mxGeometry height="60" width="120" x="660" y="210" as="geometry" />
+        </mxCell>
+        <mxCell id="zzKEAjI1_oLO3G-XxQyw-5" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="UpdateInfo" vertex="1">
+          <mxGeometry height="60" width="120" x="365" y="440" as="geometry" />
+        </mxCell>
+        <mxCell id="zzKEAjI1_oLO3G-XxQyw-6" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Missing&lt;span style=&quot;color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); background-color: transparent;&quot;&gt;Person&lt;/span&gt;&lt;span style=&quot;color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); background-color: transparent;&quot;&gt;Located&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="120" x="660" y="590" as="geometry" />
+        </mxCell>
+        <mxCell id="zzKEAjI1_oLO3G-XxQyw-9" edge="1" parent="1" source="zzKEAjI1_oLO3G-XxQyw-3" style="endArrow=classic;html=1;rounded=0;exitX=0.75;exitY=0;exitDx=0;exitDy=0;entryX=0.75;entryY=1;entryDx=0;entryDy=0;" target="zzKEAjI1_oLO3G-XxQyw-2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry">
+            <mxPoint x="400" y="620" as="sourcePoint" />
+            <mxPoint x="450" y="570" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="zzKEAjI1_oLO3G-XxQyw-10" connectable="0" parent="zzKEAjI1_oLO3G-XxQyw-9" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="(search == off)" vertex="1">
+          <mxGeometry relative="1" x="-0.0081" y="-3" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="zzKEAjI1_oLO3G-XxQyw-11" edge="1" parent="1" source="zzKEAjI1_oLO3G-XxQyw-2" style="endArrow=classic;html=1;rounded=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="zzKEAjI1_oLO3G-XxQyw-3" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry">
+            <mxPoint x="400" y="620" as="sourcePoint" />
+            <mxPoint x="410" y="210" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
       </root>
     </mxGraphModel>

--- a/test/resources/simple_example/test_cwp.xml
+++ b/test/resources/simple_example/test_cwp.xml
@@ -1,35 +1,37 @@
-<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Safari/605.1.15" version="27.0.6">
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Safari/605.1.15">
   <diagram name="CWP Diagram" id="0">
-    <mxGraphModel dx="1222" dy="1334" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+    <mxGraphModel dx="1355" dy="1169" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="2" value="Start" style="ellipse;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="50" y="150" width="80" height="80" as="geometry" />
+        <mxCell id="3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="Increment_x" vertex="1">
+          <mxGeometry height="80" width="120" x="250" y="150" as="geometry" />
         </mxCell>
-        <mxCell id="3" value="Increment_x" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="200" y="150" width="120" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="5" value="End" style="ellipse;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="600" y="150" width="80" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="6" parent="1" source="2" target="3" edge="1">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="fRexnSg4iFv55GYqwRYk-7" value="x &amp;lt;= 5" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="6">
-          <mxGeometry x="-0.0286" y="2" relative="1" as="geometry">
-            <mxPoint as="offset" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="7" style="entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="3" target="5" edge="1">
+        <mxCell id="6" edge="1" parent="1" source="-AYt-wPokLTaNUis7IPH-7" style="exitX=1;exitY=0.5;exitDx=0;exitDy=0;" target="3">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint x="400" y="190" as="targetPoint" />
+            <mxPoint x="130" y="190" as="sourcePoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="EdfAfCI1iZDf2Rz-AQtW-11" value="x &amp;gt; 5" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="7" vertex="1" connectable="0">
-          <mxGeometry x="-0.1714" y="2" relative="1" as="geometry">
+        <mxCell id="fRexnSg4iFv55GYqwRYk-7" connectable="0" parent="6" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="x &amp;lt;= 5" vertex="1">
+          <mxGeometry relative="1" x="-0.0286" y="2" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
+        </mxCell>
+        <mxCell id="7" edge="1" parent="1" source="3" style="entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="-AYt-wPokLTaNUis7IPH-9">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="600" y="190" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="EdfAfCI1iZDf2Rz-AQtW-11" connectable="0" parent="7" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" value="x &amp;gt; 5" vertex="1">
+          <mxGeometry relative="1" x="-0.1714" y="2" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="-AYt-wPokLTaNUis7IPH-7" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="Start" vertex="1">
+          <mxGeometry height="60" width="120" x="30" y="160" as="geometry" />
+        </mxCell>
+        <mxCell id="-AYt-wPokLTaNUis7IPH-9" parent="1" style="rounded=1;whiteSpace=wrap;html=1;" value="End" vertex="1">
+          <mxGeometry height="60" width="120" x="620" y="160" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>


### PR DESCRIPTION
More errors were caught, specifically those raised from the TM example provided in issue 336. Objects in the CWP are no longer allowed, along with anything besides rounded rectangles. expression_reconstructer was also fixed so that it never enters an infinite loop.

will close 336 and 337