### PR TITLE
Add Parallel Gateway support and BPMN behavior translation for CBMC

### DIFF
--- a/src/bpmncwpverify/visitors/bpmn_cbmc_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_cbmc_visitor.py
@@ -19,6 +19,8 @@ Transition naming:
   - XOR gateway outgoing flow: T_<flow.id>
 """
 
+import re
+
 from bpmncwpverify.core.bpmn import (
     BpmnVisitor,
     EndEvent,
@@ -84,6 +86,12 @@ class BpmnCbmcVisitor(BpmnVisitor):
             return places[0]
         return " || ".join(places)
 
+    def _and_of_in_places(self, node: Node) -> str:
+        places = self._in_place_names(node)
+        if len(places) == 1:
+            return places[0]
+        return " && ".join(places)
+
     def _enable_expr(self, node: Node, flow: "SequenceFlow | None") -> str:
         """C boolean expression: true when this transition may fire."""
         if isinstance(node, StartEvent):
@@ -94,10 +102,65 @@ class BpmnCbmcVisitor(BpmnVisitor):
             if flow.expression:
                 return f"({gw_in}) && ({flow.expression})"
             return f"({gw_in})"
-        # Task or EndEvent — OR of all incoming places
+        if isinstance(node, ParallelGatewayNode):
+            # Fork: OR (usually one in_place). Join: AND (all branches must complete).
+            if node.is_fork:
+                return self._or_of_in_places(node)
+            return self._and_of_in_places(node)
         return self._or_of_in_places(node)
 
-    # ── visitor callbacks ─────────────────────────────────────────────────────
+    # Matches one branch of a Promela if/fi block:  :: true -> VAR = VALUE
+    _BRANCH_RE = re.compile(r"::\s*true\s*->\s*(\w+)\s*=\s*(\S+)")
+
+    @staticmethod
+    def _translate_behavior(behavior: str) -> list[str]:
+        """Translate BPMN task behavior (Promela if/fi or plain C) to C statements."""
+        behavior = behavior.strip()
+        if not behavior:
+            return []
+
+        result: list[str] = []
+        iffi_idx = 0
+
+        raw_lines = behavior.splitlines()
+        i = 0
+        while i < len(raw_lines):
+            line = raw_lines[i].strip()
+
+            if line == "if":
+                branches: list[tuple[str, str]] = []
+                i += 1
+                while i < len(raw_lines) and raw_lines[i].strip() != "fi":
+                    m = BpmnCbmcVisitor._BRANCH_RE.match(raw_lines[i].strip())
+                    if m:
+                        branches.append((m.group(1), m.group(2)))
+                    i += 1
+                i += 1  # skip 'fi'
+
+                if branches:
+                    vars_in_order: list[str] = []
+                    for var, _ in branches:
+                        if var not in vars_in_order:
+                            vars_in_order.append(var)
+
+                    for var in vars_in_order:
+                        values = [val for v, val in branches if v == var]
+                        t_var = "t" if iffi_idx == 0 else f"t{iffi_idx}"
+                        iffi_idx += 1
+                        assume = " || ".join(f"{t_var} == {val}" for val in values)
+                        result.append(f"int {t_var} = nondet_int();")
+                        result.append(f"__CPROVER_assume({assume});")
+                        result.append(f"{var} = {t_var};")
+
+            elif line:
+                stmt = line if line.endswith(";") else line + ";"
+                result.append(stmt)
+                i += 1
+
+            else:
+                i += 1
+
+        return result
 
     def visit_start_event(self, event: StartEvent) -> bool:
         if event.id in self._visited_ids:
@@ -140,8 +203,11 @@ class BpmnCbmcVisitor(BpmnVisitor):
         return True
 
     def visit_parallel_gateway(self, gateway: ParallelGatewayNode) -> bool:
-        self.error = CbmcUnsupportedElementError(gateway.id, "ParallelGatewayNode")
-        return False
+        if gateway.id in self._visited_ids:
+            return False
+        self._visited_ids.add(gateway.id)
+        self._transitions.append((gateway, None))
+        return True
 
     def visit_intermediate_event(self, event: IntermediateEvent) -> bool:
         self.error = CbmcUnsupportedElementError(event.id, "IntermediateEvent")
@@ -154,10 +220,10 @@ class BpmnCbmcVisitor(BpmnVisitor):
         return len(self._transitions)
 
     def compute_bound(self) -> int:
-        """STUB: returns num_transitions × 4 — a magic-number placeholder.
+        """STUB: returns num_transitions × 4 — replace with R5a longest-path algorithm.
 
         An undersized bound causes silent false confidence (CBMC reports
-        VERIFICATION SUCCESSFUL without full coverage). Replace with the
+        VERIFICATION SUCCESSFUL without exploring all paths).
         R5a longest-path algorithm (see cbmc_generator_requirements.md).
         """
         return self.num_transitions * 4

--- a/src/bpmncwpverify/visitors/bpmn_cbmc_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_cbmc_visitor.py
@@ -377,23 +377,14 @@ class BpmnCbmcVisitor(BpmnVisitor):
                 lines.append(f"            {self._flow_place_name(f)} = true;")
 
         elif isinstance(node, Task):
-            # Consume all incoming places (OR-merge: zero every in_flow slot).
             for f in node.in_flows:
                 lines.append(f"            {self._flow_place_name(f)} = false;")
-            # Execute behavior statements.
-            behavior = node.behavior.strip()
-            if behavior:
-                for stmt in behavior.splitlines():
-                    stmt = stmt.strip()
-                    if stmt:
-                        if not stmt.endswith(";"):
-                            stmt += ";"
-                        lines.append(f"            {stmt}")
-            # Produce all outgoing flow places.
+            translated = self._translate_behavior(node.behavior)
+            for stmt in translated:
+                lines.append(f"            {stmt}")
             for f in node.out_flows:
                 lines.append(f"            {self._flow_place_name(f)} = true;")
-            # Call update_cwp_state after any state-modifying task.
-            if behavior:
+            if translated:
                 args = ", ".join(["&cwp_state", "cwp_reached"] + var_args)
                 lines.append(f"            update_cwp_state({args});")
 

--- a/src/bpmncwpverify/visitors/bpmn_cbmc_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_cbmc_visitor.py
@@ -114,12 +114,27 @@ class BpmnCbmcVisitor(BpmnVisitor):
 
     @staticmethod
     def _translate_behavior(behavior: str) -> list[str]:
-        """Translate BPMN task behavior (Promela if/fi or plain C) to C statements."""
+        """Translate BPMN task behavior (if/fi blocks or plain statements) to C.
+
+        if/fi blocks encode nondeterministic assignment:
+            if
+            :: true -> var = VALUE_A
+            :: true -> var = VALUE_B
+            fi
+        Each block is translated to the CBMC nondet/assume idiom:
+            int t = nondet_int();
+            __CPROVER_assume(t == VALUE_A || t == VALUE_B);
+            var = t;
+        Plain statements (no if/fi) are passed through with a semicolon added
+        if missing. Empty behavior returns [].
+        """
         behavior = behavior.strip()
         if not behavior:
             return []
 
         result: list[str] = []
+        # Counts if/fi blocks seen so far; used to name temp vars t, t1, t2, ...
+        # to avoid redeclaration when a single task has multiple if/fi blocks.
         iffi_idx = 0
 
         raw_lines = behavior.splitlines()
@@ -128,6 +143,7 @@ class BpmnCbmcVisitor(BpmnVisitor):
             line = raw_lines[i].strip()
 
             if line == "if":
+                # Collect all :: true -> VAR = VALUE branches until 'fi'.
                 branches: list[tuple[str, str]] = []
                 i += 1
                 while i < len(raw_lines) and raw_lines[i].strip() != "fi":
@@ -138,13 +154,16 @@ class BpmnCbmcVisitor(BpmnVisitor):
                 i += 1  # skip 'fi'
 
                 if branches:
+                    # Deduplicate variable names, preserving first-appearance order.
                     vars_in_order: list[str] = []
                     for var, _ in branches:
                         if var not in vars_in_order:
                             vars_in_order.append(var)
 
+                    # Emit one nondet/assume triple per variable.
                     for var in vars_in_order:
                         values = [val for v, val in branches if v == var]
+                        # First block uses 't'; subsequent blocks use 't1', 't2', ...
                         t_var = "t" if iffi_idx == 0 else f"t{iffi_idx}"
                         iffi_idx += 1
                         assume = " || ".join(f"{t_var} == {val}" for val in values)
@@ -153,6 +172,7 @@ class BpmnCbmcVisitor(BpmnVisitor):
                         result.append(f"{var} = {t_var};")
 
             elif line:
+                # Plain statement — pass through, ensuring it ends with a semicolon.
                 stmt = line if line.endswith(";") else line + ";"
                 result.append(stmt)
                 i += 1

--- a/src/bpmncwpverify/visitors/bpmn_cbmc_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_cbmc_visitor.py
@@ -396,6 +396,12 @@ class BpmnCbmcVisitor(BpmnVisitor):
             # Produce the selected outgoing place.
             lines.append(f"            {self._flow_place_name(flow)} = true;")
 
+        elif isinstance(node, ParallelGatewayNode):
+            for f in node.in_flows:
+                lines.append(f"            {self._flow_place_name(f)} = false;")
+            for f in node.out_flows:
+                lines.append(f"            {self._flow_place_name(f)} = true;")
+
         elif isinstance(node, EndEvent):
             # Consume all incoming places.
             for f in node.in_flows:

--- a/test/visitors/test_bpmn_cbmc_visitor.py
+++ b/test/visitors/test_bpmn_cbmc_visitor.py
@@ -342,6 +342,36 @@ def test_transition_body_end_event(visitor, mocker):
     assert any("running = false;" in line for line in lines)
 
 
+def test_transition_body_parallel_gateway_fork(visitor, mocker):
+    gw = mocker.Mock(spec=ParallelGatewayNode)
+    gw.id = "gw_fork"
+    gw.is_fork = True
+    in_flow = make_flow(mocker, "task_1", "gw_fork", "f_in")
+    out_flow_a = make_flow(mocker, "gw_fork", "task_a", "f_out_a")
+    out_flow_b = make_flow(mocker, "gw_fork", "task_b", "f_out_b")
+    gw.in_flows = [in_flow]
+    gw.out_flows = [out_flow_a, out_flow_b]
+    lines = visitor._transition_body(gw, None, [])
+    assert any("p_gw_fork_FROM_task_1 = false;" in line for line in lines)
+    assert any("p_task_a_FROM_gw_fork = true;" in line for line in lines)
+    assert any("p_task_b_FROM_gw_fork = true;" in line for line in lines)
+
+
+def test_transition_body_parallel_gateway_join(visitor, mocker):
+    gw = mocker.Mock(spec=ParallelGatewayNode)
+    gw.id = "gw_join"
+    gw.is_fork = False
+    in_flow_a = make_flow(mocker, "task_a", "gw_join", "f_in_a")
+    in_flow_b = make_flow(mocker, "task_b", "gw_join", "f_in_b")
+    out_flow = make_flow(mocker, "gw_join", "task_2", "f_out")
+    gw.in_flows = [in_flow_a, in_flow_b]
+    gw.out_flows = [out_flow]
+    lines = visitor._transition_body(gw, None, [])
+    assert any("p_gw_join_FROM_task_a = false;" in line for line in lines)
+    assert any("p_gw_join_FROM_task_b = false;" in line for line in lines)
+    assert any("p_task_2_FROM_gw_join = true;" in line for line in lines)
+
+
 # ── behavior translation ──────────────────────────────────────────────────────
 
 

--- a/test/visitors/test_bpmn_cbmc_visitor.py
+++ b/test/visitors/test_bpmn_cbmc_visitor.py
@@ -225,12 +225,26 @@ def test_visit_sequence_flow_does_not_overwrite_existing(visitor, mocker):
     assert visitor._places["p_TGT_FROM_SRC"] is True
 
 
-def test_visit_parallel_gateway_sets_error(visitor, mocker):
+def test_visit_parallel_gateway_registers_transition(visitor, mocker):
+    # Parallel gateways are supported (added in Sprint 1) — one transition regardless of fork/join.
     gw = mocker.Mock(spec=ParallelGatewayNode)
     gw.id = "gw_par"
+    gw.is_fork = True
+    result = visitor.visit_parallel_gateway(gw)
+    assert result is True
+    assert visitor.error is None
+    assert len(visitor._transitions) == 1
+    assert visitor._transitions[0] == (gw, None)
+
+
+def test_visit_parallel_gateway_deduplicates(visitor, mocker):
+    gw = mocker.Mock(spec=ParallelGatewayNode)
+    gw.id = "gw_par"
+    gw.is_fork = True
+    visitor.visit_parallel_gateway(gw)
     result = visitor.visit_parallel_gateway(gw)
     assert result is False
-    assert isinstance(visitor.error, CbmcUnsupportedElementError)
+    assert len(visitor._transitions) == 1
 
 
 def test_visit_intermediate_event_sets_error(visitor, mocker):
@@ -271,6 +285,29 @@ def test_transition_body_task_with_behavior(visitor, mocker):
     )
 
 
+def test_transition_body_task_with_promela_behavior(visitor, mocker):
+    task = mocker.Mock(spec=Task)
+    task.id = "task_1"
+    task.behavior = "if\n:: true -> terms = agreed\n:: true -> terms = failed\nfi"
+    in_flow = make_flow(mocker, "ev_start", "task_1", "f_in")
+    out_flow = make_flow(mocker, "task_1", "gw_1", "f_out")
+    task.in_flows = [in_flow]
+    task.out_flows = [out_flow]
+    lines = visitor._transition_body(task, None, ["terms"])
+    assert any("int t = nondet_int();" in line for line in lines)
+    assert any(
+        "__CPROVER_assume(t == agreed || t == failed);" in line for line in lines
+    )
+    assert any("terms = t;" in line for line in lines)
+    assert any(
+        "update_cwp_state(&cwp_state, cwp_reached, terms);" in line for line in lines
+    )
+    # Raw Promela syntax must NOT appear verbatim in the output.
+    assert not any(":: true" in line for line in lines)
+    assert not any(line.strip() == "if" for line in lines)
+    assert not any(line.strip() == "fi" for line in lines)
+
+
 def test_transition_body_task_without_behavior_no_update_call(visitor, mocker):
     task = mocker.Mock(spec=Task)
     task.id = "task_1"
@@ -303,6 +340,100 @@ def test_transition_body_end_event(visitor, mocker):
     assert any("p_ev_end_FROM_gw_1 = false;" in line for line in lines)
     assert any("ev_end_reached = true;" in line for line in lines)
     assert any("running = false;" in line for line in lines)
+
+
+# ── behavior translation ──────────────────────────────────────────────────────
+
+
+class TestTranslateBehavior:
+    """Unit tests for BpmnCbmcVisitor._translate_behavior (static method)."""
+
+    # ── empty / whitespace ────────────────────────────────────────────────────
+
+    def test_empty_string_returns_empty(self):
+        assert BpmnCbmcVisitor._translate_behavior("") == []
+
+    def test_whitespace_only_returns_empty(self):
+        assert BpmnCbmcVisitor._translate_behavior("   \n  ") == []
+
+    # ── plain C passthrough ───────────────────────────────────────────────────
+
+    def test_single_plain_assignment_gets_semicolon(self):
+        result = BpmnCbmcVisitor._translate_behavior("backpackOwner = sellerName")
+        assert result == ["backpackOwner = sellerName;"]
+
+    def test_plain_assignment_with_existing_semicolon_not_doubled(self):
+        result = BpmnCbmcVisitor._translate_behavior("backpackOwner = sellerName;")
+        assert result == ["backpackOwner = sellerName;"]
+
+    def test_multiline_plain_assignments(self):
+        behavior = "backpackOwner = sellerName\npaymentOwner = buyerName"
+        result = BpmnCbmcVisitor._translate_behavior(behavior)
+        assert result == [
+            "backpackOwner = sellerName;",
+            "paymentOwner = buyerName;",
+        ]
+
+    # ── Promela if/fi → nondet/assume ────────────────────────────────────────
+
+    def test_iffi_two_values(self):
+        behavior = "if\n:: true -> terms = agreed\n:: true -> terms = failed\nfi"
+        result = BpmnCbmcVisitor._translate_behavior(behavior)
+        assert result == [
+            "int t = nondet_int();",
+            "__CPROVER_assume(t == agreed || t == failed);",
+            "terms = t;",
+        ]
+
+    def test_iffi_three_values(self):
+        behavior = (
+            "if\n"
+            ":: true -> paymentOffered = paymentAmount\n"
+            ":: true -> paymentOffered = belowPaymentAmount\n"
+            ":: true -> paymentOffered = noRetryPayment\n"
+            "fi"
+        )
+        result = BpmnCbmcVisitor._translate_behavior(behavior)
+        assert result == [
+            "int t = nondet_int();",
+            "__CPROVER_assume(t == paymentAmount || t == belowPaymentAmount || t == noRetryPayment);",
+            "paymentOffered = t;",
+        ]
+
+    def test_iffi_with_leading_trailing_whitespace(self):
+        # The visitor strips behavior before processing.
+        behavior = "\nif\n:: true -> x = a\n:: true -> x = b\nfi\n"
+        result = BpmnCbmcVisitor._translate_behavior(behavior)
+        assert result == [
+            "int t = nondet_int();",
+            "__CPROVER_assume(t == a || t == b);",
+            "x = t;",
+        ]
+
+    def test_two_iffi_blocks_use_indexed_temp_vars(self):
+        # Two separate if/fi blocks in one task (unusual but must not redeclare 't').
+        behavior = (
+            "if\n:: true -> a = x\n:: true -> a = y\nfi\n"
+            "if\n:: true -> b = p\n:: true -> b = q\nfi"
+        )
+        result = BpmnCbmcVisitor._translate_behavior(behavior)
+        assert result == [
+            "int t = nondet_int();",
+            "__CPROVER_assume(t == x || t == y);",
+            "a = t;",
+            "int t1 = nondet_int();",
+            "__CPROVER_assume(t1 == p || t1 == q);",
+            "b = t1;",
+        ]
+
+    def test_three_iffi_blocks_use_sequential_index(self):
+        block = "if\n:: true -> v = a\n:: true -> v = b\nfi\n"
+        behavior = block * 3
+        result = BpmnCbmcVisitor._translate_behavior(behavior)
+        # First block: t, second: t1, third: t2
+        assert result[0] == "int t = nondet_int();"
+        assert result[3] == "int t1 = nondet_int();"
+        assert result[6] == "int t2 = nondet_int();"
 
 
 # ── code generation ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `ParallelGatewayNode` support to `BpmnCbmcVisitor` (previously returned `CbmcUnsupportedElementError`); fork uses OR-of-in-places enable, join uses AND-of-in-places
- Extracts a `_translate_behavior` static helper that converts BPMN task behavior `if/fi` blocks into CBMC-compatible C (`nondet_int()` + `__CPROVER_assume()`), with sequential temp-var naming (`t`, `t1`, `t2`, …) to avoid redeclaration
- Refactors task behavior emission in `_transition_body` to use the new helper; plain C statements still pass through unchanged

## Test plan

- [x] `pytest test/visitors/test_bpmn_cbmc_visitor.py` — all new and updated tests pass
- [x] Parallel gateway deduplication: calling `visit_parallel_gateway` twice on the same ID registers only one transition
- [x] `_translate_behavior` unit suite covers: empty input, plain C passthrough, 2/3-value `if/fi`, multi-block indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)