### PR TITLE
Add CBMC to Docker image and CI workflow

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install CBMC
       run: |
-        CBMC_VERSION=6.9.0
+        CBMC_VERSION=$(grep 'ARG CBMC_VERSION=' Dockerfile | cut -d= -f2)
         wget -q https://github.com/diffblue/cbmc/releases/download/cbmc-${CBMC_VERSION}/ubuntu-22.04-cbmc-${CBMC_VERSION}-Linux.deb
         sudo dpkg -i ubuntu-22.04-cbmc-${CBMC_VERSION}-Linux.deb
         cbmc --version

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -28,6 +28,12 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install CBMC
+      run: |
+        CBMC_VERSION=6.9.0
+        wget -q https://github.com/diffblue/cbmc/releases/download/cbmc-${CBMC_VERSION}/ubuntu-22.04-cbmc-${CBMC_VERSION}-Linux.deb
+        sudo dpkg -i ubuntu-22.04-cbmc-${CBMC_VERSION}-Linux.deb
+        cbmc --version
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 # ============================================================================
-# Base stage: Common setup (Spin binary + gcc for Lambda compatibility)
+# Base stage: Common setup (Spin + CBMC + gcc for Lambda compatibility)
+# Both dev and lambda extend this stage — they stay in sync automatically.
 # ============================================================================
 FROM public.ecr.aws/lambda/python:3.12 AS base
 
 # Install build tools and runtime dependencies
-# bison provides yacc (needed to build Spin)
-# Create yacc wrapper that uses bison -y for yacc compatibility
-RUN microdnf -y install gcc make tar gzip xz ca-certificates zip which wget bison git \
+# bison provides yacc (needed to build Spin and CBMC)
+# cmake + gcc-c++ + flex are needed to build CBMC from source
+# (no pre-built CBMC binary exists for Amazon Linux)
+RUN microdnf -y install gcc gcc-c++ make cmake tar gzip xz ca-certificates zip which wget bison flex git patch \
     && microdnf -y clean all \
     && printf '#!/usr/bin/bash\nexec /usr/bin/bison -y "$@"\n' > /usr/bin/yacc \
     && chmod +x /usr/bin/yacc
@@ -24,11 +26,28 @@ RUN wget https://github.com/nimble-code/Spin/archive/refs/tags/version-${SPIN_VE
     cd / && \
     rm -rf Spin-version-${SPIN_VERSION} version-${SPIN_VERSION}.tar.gz
 
-# Ensure Spin is on PATH
+ARG CBMC_VERSION=6.9.0
+
+# Build CBMC from source. -DWITH_JBMC=OFF skips the Java BMC component,
+# avoiding a Java dependency and keeping the image smaller.
+RUN git clone --depth 1 --branch cbmc-${CBMC_VERSION} \
+        https://github.com/diffblue/cbmc.git /tmp/cbmc && \
+    cd /tmp/cbmc && \
+    git submodule update --init && \
+    cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DWITH_JBMC=OFF && \
+    cmake --build build --target cbmc -j$(nproc) && \
+    cp build/bin/cbmc /opt/bin/cbmc && \
+    rm -rf /tmp/cbmc
+
+# Ensure Spin and CBMC are on PATH
 ENV PATH=/opt/bin:$PATH
 
 # ============================================================================
-# Development stage: For local development with hot reload
+# Development stage: Adds Node.js (pyright) and installs the package in
+# editable mode on top of base. Dev and lambda use the same base so their
+# Spin/CBMC binaries are always identical.
 # ============================================================================
 FROM base AS dev
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,4 @@ disallow_subclassing_any = true
 
 [tool.pytest.ini_options]
 addopts = "--cov=./src/bpmncwpverify/ --cov-report=html --cov-report=term"
+pythonpath = ["."]


### PR DESCRIPTION
## Summary

- Updates `Dockerfile` to build CBMC from source in the `base` stage (no pre-built binary exists for Amazon Linux); uses `cmake` with `-DWITH_JBMC=OFF` to skip the Java BMC component and keep the image lean; pins version via `ARG CBMC_VERSION=6.9.0`
- Adds required build deps (`gcc-c++`, `cmake`, `flex`, `patch`) to the `microdnf` install
- Adds a CI step to `development.yaml` that reads `CBMC_VERSION` from the Dockerfile and installs the matching Ubuntu `.deb` so the GitHub Actions runner has `cbmc` available during tests

## Test plan

- [x] Docker build completes without error and `cbmc --version` runs in the image
- [x] CI workflow installs CBMC and `cbmc --version` passes in the GitHub Actions runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)