### PR TITLE
Fixed pml indentation and added more error info

### DIFF
--- a/src/bpmncwpverify/core/counterexample.py
+++ b/src/bpmncwpverify/core/counterexample.py
@@ -14,7 +14,7 @@ class ErrorTrace:
 
     __slots__ = ["id", "changed_vars", "cur_cwp_state", "related_variables"]
 
-    def __init__(self, id: str, changed_vars: list[str], cur_cwp_state: str):
+    def __init__(self, id: str, changed_vars: list[str], cur_cwp_state: list[str]):
         self.id = id
         self.changed_vars = changed_vars
         self.cur_cwp_state = cur_cwp_state
@@ -119,7 +119,7 @@ class CounterExample:
         steps: list[ErrorTrace] = []
         id = ""
         changed_variables: list[str] = []
-        state = ""
+        state: list[str] = []
         issue = ""
 
         while line_index < len(lines):
@@ -131,7 +131,7 @@ class CounterExample:
                 elif id in bpmn.id_to_element:
                     id = bpmn.id_to_element[id].name
 
-                state = ""
+                state = []
                 line_index += 1
 
             elif "Changed Vars:" in lines[line_index]:
@@ -143,7 +143,7 @@ class CounterExample:
                     line_index += 1
 
             elif "Current state:" in lines[line_index]:
-                state = lines[line_index].split(":", 1)[1].strip()
+                state.append(lines[line_index].split(":", 1)[1].strip())
                 line_index += 1
 
             else:

--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -763,7 +763,7 @@ def get_error_message(error: Error) -> str:
             errors.append(counter_example)
             return "\n".join(errors)
         case SpinCoverageError(coverage_errors=coverage_errors):
-            return "Sping Coverage Error:\n" + "\n".join(
+            return "Spin Coverage Error:\n" + "\n".join(
                 [
                     f"Proctype: {error['proctype']}, File: {error['file']}, Line: {str(error['line'])}, Message: {error['message']}"
                     for error in coverage_errors

--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -763,7 +763,7 @@ def get_error_message(error: Error) -> str:
             errors.append(counter_example)
             return "\n".join(errors)
         case SpinCoverageError(coverage_errors=coverage_errors):
-            return "\n".join(
+            return "Sping Coverage Error:\n" + "\n".join(
                 [
                     f"Proctype: {error['proctype']}, File: {error['file']}, Line: {str(error['line'])}, Message: {error['message']}"
                     for error in coverage_errors

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -314,9 +314,9 @@ class PromelaGenVisitor(BpmnVisitor):
     def end_visit_process(self, process: Process) -> None:
         self.promela.write_str(self.local_var_defs, indent_offset=1)
         self.promela.write_str("", NL_SINGLE)
+        self.promela.write_str(f'DBG(printf("ID: {process.id}\\n"))', NL_SINGLE)
 
         self.promela.write_str("d_step {", NL_SINGLE, IndentAction.INC)
-        self.promela.write_str(f'DBG(printf("ID: {process.id}\\n"))', NL_SINGLE)
         self.promela.write_str("DBG(stateLogger())", NL_SINGLE)
         self.promela.write_str("pid me = _pid", NL_SINGLE, IndentAction.NIL)
 
@@ -440,13 +440,14 @@ class AtomicBuilder:
         self,
     ) -> StringManager:
         structure = StringManager()
+        structure.write_str(
+            f'DBG(printf("ID: {self.context.element.id}\\n"))', NL_SINGLE
+        )
         if self.context.behavior:
             structure.write_str(f"{self.context.element.id}_BehaviorModel()", NL_SINGLE)
 
         structure.write_str("d_step {", NL_SINGLE, IndentAction.INC)
-        structure.write_str(
-            f'DBG(printf("ID: {self.context.element.id}\\n"))', NL_SINGLE
-        )
+
         structure.write_str("DBG(stateLogger())", NL_SINGLE)
         return structure
 

--- a/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/bpmn_promela_visitor.py
@@ -314,9 +314,9 @@ class PromelaGenVisitor(BpmnVisitor):
     def end_visit_process(self, process: Process) -> None:
         self.promela.write_str(self.local_var_defs, indent_offset=1)
         self.promela.write_str("", NL_SINGLE)
-        self.promela.write_str(f'DBG(printf("ID: {process.id}\\n"))', NL_SINGLE)
 
         self.promela.write_str("d_step {", NL_SINGLE, IndentAction.INC)
+        self.promela.write_str(f'DBG(printf("ID: {process.id}\\n"))', NL_SINGLE)
         self.promela.write_str("DBG(stateLogger())", NL_SINGLE)
         self.promela.write_str("pid me = _pid", NL_SINGLE, IndentAction.NIL)
 
@@ -331,6 +331,7 @@ class PromelaGenVisitor(BpmnVisitor):
         self.init_proc_contents.write_str("atomic {", NL_SINGLE, IndentAction.INC)
         self.init_proc_contents.write_str("DBG(stateDump())", NL_SINGLE)
         self.init_proc_contents.write_str("caculateState()", NL_SINGLE)
+        self.init_proc_contents.write_str("updateState()", NL_SINGLE)
         return True
 
     def end_visit_bpmn(self, bpmn: Bpmn) -> None:

--- a/src/bpmncwpverify/visitors/cwp_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/cwp_promela_visitor.py
@@ -104,10 +104,11 @@ class CwpPromelaVisitor(CwpVisitor):
         nWayXor.write_str("if", NL_SINGLE, IndentAction.INC)
 
         nWayXor.write_str(":: (sumOfActiveStates != 1) ->", NL_SINGLE, IndentAction.INC)
+        nWayXor.write_str("DBG(stateLogger())", NL_SINGLE)
         nWayXor.write_str(
             'DBG(printf("Assert: In more that one or no state"))', NL_SINGLE
         )
-        nWayXor.write_str("DBG(stateLogger())", NL_SINGLE)
+
         nWayXor.write_str("assert(false)", NL_SINGLE)
 
         nWayXor.write_str(":: else -> skip", NL_SINGLE, IndentAction.DEC)

--- a/src/bpmncwpverify/visitors/cwp_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/cwp_promela_visitor.py
@@ -145,11 +145,11 @@ class CwpPromelaVisitor(CwpVisitor):
         new_str = "inline updateState() {"
         self.update_state_inline.write_str(new_str, NL_SINGLE, IndentAction.INC)
 
-        self.update_state_inline.write_str(self.prime_vars)
+        self.update_state_inline.write_str(self.prime_vars, indent_offset=1)
 
         self.update_state_inline.write_str("if", NL_SINGLE, IndentAction.INC)
 
-        self.update_state_inline.write_str(self.proper_path_block)
+        self.update_state_inline.write_str(self.proper_path_block, indent_offset=1)
 
         self.update_state_inline.write_str(":: else ->", NL_SINGLE, IndentAction.INC)
         self.update_state_inline.write_str(
@@ -159,9 +159,9 @@ class CwpPromelaVisitor(CwpVisitor):
 
         self.update_state_inline.write_str("fi", NL_SINGLE, IndentAction.DECTWO)
 
-        self.update_state_inline.write_str(self.var_reassignment)
+        self.update_state_inline.write_str(self.var_reassignment, indent_offset=1)
 
-        self.update_state_inline.write_str(self.build_XOR_block())
+        self.update_state_inline.write_str(self.build_XOR_block(), indent_offset=1)
 
         self.update_state_inline.write_str("}", NL_DOUBLE, IndentAction.DEC)
 
@@ -170,7 +170,7 @@ class CwpPromelaVisitor(CwpVisitor):
             "inline caculateState() {", NL_SINGLE, IndentAction.INC
         )
 
-        self.caculate_state_inline.write_str(self.vars)
+        self.caculate_state_inline.write_str(self.vars, indent_offset=1)
 
         self.caculate_state_inline.write_str("}", NL_DOUBLE, IndentAction.DEC)
 

--- a/src/bpmncwpverify/visitors/cwp_promela_visitor.py
+++ b/src/bpmncwpverify/visitors/cwp_promela_visitor.py
@@ -107,6 +107,7 @@ class CwpPromelaVisitor(CwpVisitor):
         nWayXor.write_str(
             'DBG(printf("Assert: In more that one or no state"))', NL_SINGLE
         )
+        nWayXor.write_str("DBG(stateLogger())", NL_SINGLE)
         nWayXor.write_str("assert(false)", NL_SINGLE)
 
         nWayXor.write_str(":: else -> skip", NL_SINGLE, IndentAction.DEC)

--- a/test/core/test_counterexample.py
+++ b/test/core/test_counterexample.py
@@ -78,4 +78,4 @@ def test_counterexample_extract_steps(mocker):
     assert len(steps) == 1
     assert steps[0].id == "start"
     assert steps[0].changed_vars == ["test_var1", "test_var2"]
-    assert steps[0].cur_cwp_state == "test_state1"
+    assert steps[0].cur_cwp_state == ["test_state1"]

--- a/test/core/test_error.py
+++ b/test/core/test_error.py
@@ -266,7 +266,7 @@ test_inputs: list[tuple[Error, str]] = [
                 }
             ],
         ),
-        "Proctype: test_proctype, File: test_file, Line: test_line, Message: test_message",
+        "Sping Coverage Error:\nProctype: test_proctype, File: test_file, Line: test_line, Message: test_message",
     ),
     (
         SpinInvalidEndStateError("", [{"info": "test_info1"}, {"info": "test_info2"}]),

--- a/test/core/test_error.py
+++ b/test/core/test_error.py
@@ -266,7 +266,7 @@ test_inputs: list[tuple[Error, str]] = [
                 }
             ],
         ),
-        "Sping Coverage Error:\nProctype: test_proctype, File: test_file, Line: test_line, Message: test_message",
+        "Spin Coverage Error:\nProctype: test_proctype, File: test_file, Line: test_line, Message: test_message",
     ),
     (
         SpinInvalidEndStateError("", [{"info": "test_info1"}, {"info": "test_info2"}]),

--- a/test/visitors/test_bpmn_promela_visitor.py
+++ b/test/visitors/test_bpmn_promela_visitor.py
@@ -379,7 +379,7 @@ def test_build_atomic_block(promela_visitor, mocker):
     builder = AtomicBuilder(ctx)
     atomic_block = builder.build_atomic_block()
 
-    expected_output = ':: atomic { ((hasToken(NODE1_FROM_NODE2) || hasToken(NODE1_FROM_NODE3))) ->\n\tNODE1_BehaviorModel()\n\td_step {\n\t\tDBG(printf("ID: NODE1\\n"))\n\t\tDBG(stateLogger())\n\t\tconsumeToken(NODE1_FROM_NODE2)\n\t\tconsumeToken(NODE1_FROM_NODE3)\n\t\tputToken(NODE4_FROM_NODE1)\n\t}\n}\n'
+    expected_output = ':: atomic { ((hasToken(NODE1_FROM_NODE2) || hasToken(NODE1_FROM_NODE3))) ->\n\tDBG(printf("ID: NODE1\\n"))\n\tNODE1_BehaviorModel()\n\td_step {\n\t\tDBG(stateLogger())\n\t\tconsumeToken(NODE1_FROM_NODE2)\n\t\tconsumeToken(NODE1_FROM_NODE3)\n\t\tputToken(NODE4_FROM_NODE1)\n\t}\n}\n'
     assert str(atomic_block) == expected_output
 
 

--- a/test/visitors/test_cwp_promela_visitor.py
+++ b/test/visitors/test_cwp_promela_visitor.py
@@ -167,6 +167,7 @@ class TestCwpPromelaVisitor:
             mocker.call("state1 + state2 + state3", NL_DOUBLE),
             mocker.call("if", NL_SINGLE, IndentAction.INC),
             mocker.call(":: (sumOfActiveStates != 1) ->", NL_SINGLE, IndentAction.INC),
+            mocker.call("DBG(stateLogger())", NL_SINGLE),
             mocker.call(
                 'DBG(printf("Assert: In more that one or no state"))', NL_SINGLE
             ),

--- a/test/visitors/test_cwp_promela_visitor.py
+++ b/test/visitors/test_cwp_promela_visitor.py
@@ -40,15 +40,15 @@ class TestCwpPromelaVisitor:
 
         calls = [
             mocker.call("inline updateState() {", NL_SINGLE, IndentAction.INC),
-            mocker.call(prime_vars),
+            mocker.call(prime_vars, indent_offset=1),
             mocker.call("if", NL_SINGLE, IndentAction.INC),
-            mocker.call(proper_path_block),
+            mocker.call(proper_path_block, indent_offset=1),
             mocker.call(":: else ->", NL_SINGLE, IndentAction.INC),
             mocker.call('DBG(printf("Assert: Not a valid CWP transition"))', NL_SINGLE),
             mocker.call("assert(false)", NL_SINGLE),
             mocker.call("fi", NL_SINGLE, IndentAction.DECTWO),
-            mocker.call(var_reassignment),
-            mocker.call("test_val"),
+            mocker.call(var_reassignment, indent_offset=1),
+            mocker.call("test_val", indent_offset=1),
             mocker.call("}", NL_DOUBLE, IndentAction.DEC),
         ]
 


### PR DESCRIPTION
Fixed some Promela indentation on code generated from CWP.
Added "Spin Coverage Error:" at the top of those errors for understandability.