### PR TITLE
Remove __eq__ from errors

### DIFF
--- a/src/bpmncwpverify/core/error.py
+++ b/src/bpmncwpverify/core/error.py
@@ -1,7 +1,6 @@
 # TODO: create a "match" function on Failure(Error) and create standard error messaging.
 import builtins
 import re
-import typing
 from xml.etree.ElementTree import Element
 
 import requests
@@ -295,11 +294,6 @@ class ExpressionComputationCompatabilityError(Error):
         self.ltype = ltype
         self.rtype = rtype
 
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, ExpressionComputationCompatabilityError):
-            return self.ltype == other.ltype and self.rtype == other.rtype
-        return False
-
 
 class ExpressionNegatorError(Error):
     __slots__ = ["type"]
@@ -307,11 +301,6 @@ class ExpressionNegatorError(Error):
     def __init__(self, type: str) -> None:
         super().__init__()
         self.type = type
-
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, ExpressionNegatorError):
-            return self.type == other.type
-        return False
 
 
 class ExpressionParseError(Error):
@@ -329,11 +318,6 @@ class ExpressionRelationCompatabilityError(Error):
         super().__init__()
         self.ltype = ltype
         self.rtype = rtype
-
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, ExpressionComputationCompatabilityError):
-            return self.ltype == other.ltype and self.rtype == other.rtype
-        return False
 
 
 class ExpressionIfBranchCompatabilityError(Error):
@@ -361,11 +345,6 @@ class ExpressionLogicalCompatibilityError(Error):
         self.ltype = ltype
         self.rtype = rtype
 
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, ExpressionComputationCompatabilityError):
-            return self.ltype == other.ltype and self.rtype == other.rtype
-        return False
-
 
 class ExpressionRelationalNotError(Error):
     __slots__ = ["type"]
@@ -374,11 +353,6 @@ class ExpressionRelationalNotError(Error):
         super().__init__()
         self.type = type
 
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, ExpressionRelationalNotError):
-            return self.type == other.type
-        return False
-
 
 class ExpressionUnrecognizedID(Error):
     __slots__ = ["id"]
@@ -386,11 +360,6 @@ class ExpressionUnrecognizedID(Error):
     def __init__(self, id: str) -> None:
         super().__init__()
         self.id = id
-
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, ExpressionUnrecognizedID):
-            return self.id == other.id
-        return False
 
 
 class ExpressionOutOfScope(Error):
@@ -564,16 +533,6 @@ class StateInitNotInValues(Error):
         self.column = column
         self.values = values
 
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, StateInitNotInValues):
-            return (
-                self.id == other.id
-                and self.line == other.line
-                and self.column == other.column
-                and self.values == other.values
-            )
-        return False
-
 
 class StateMultipleDefinitionError(Error):
     __slots__ = ("id", "line", "column", "prev_line", "prev_column")
@@ -593,17 +552,6 @@ class StateMultipleDefinitionError(Error):
         self.prev_line = prev_line
         self.prev_column = prev_column
 
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, StateMultipleDefinitionError):
-            return (
-                self.id == other.id
-                and self.line == other.line
-                and self.column == other.column
-                and self.prev_line == other.prev_line
-                and self.prev_column == other.prev_column
-            )
-        return False
-
 
 class StateArraySizeError(Error):
     __slots__ = ["id", "line", "column", "expected_size", "actual_size"]
@@ -622,17 +570,6 @@ class StateArraySizeError(Error):
         self.column = column
         self.expected_size = expected_size
         self.actual_size = actual_size
-
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, StateArraySizeError):
-            return (
-                self.id == other.id
-                and self.line == other.line
-                and self.column == other.column
-                and self.expected_size == other.expected_size
-                and self.actual_size == other.actual_size
-            )
-        return False
 
     def __str__(self) -> str:
         return (
@@ -715,11 +652,6 @@ class TypingAssignCompatabilityError(Error):
         self.ltype = ltype
         self.rtype = rtype
 
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, TypingAssignCompatabilityError):
-            return self.ltype == other.ltype and self.rtype == other.rtype
-        return False
-
 
 class TypingTripleVariableError(Error):
     __slots__ = ["id"]
@@ -757,11 +689,6 @@ class TypingNoTypeError(Error):
     def __init__(self, id: str) -> None:
         super().__init__()
         self.id = id
-
-    def __eq__(self, other: typing.Any) -> bool:
-        if isinstance(other, TypingNoTypeError):
-            return self.id == other.id
-        return False
 
 
 class TypingNotNonBoolError(Error):

--- a/test/core/test_state.py
+++ b/test/core/test_state.py
@@ -257,7 +257,31 @@ class Test_SymbolTable_build:
         # then
         assert not_(is_successful)(result)
         error: Error = result.failure()
-        assert expected == error
+
+        assert type(error) is type(expected)
+        match error:
+            case StateMultipleDefinitionError():
+                assert error.id == expected.id
+                assert error.column == expected.column
+                assert error.line == expected.line
+                assert error.prev_line == expected.prev_line
+                assert error.prev_column == expected.prev_column
+            case TypingNoTypeError():
+                assert error.id == expected.id
+            case TypingAssignCompatabilityError():
+                assert error.ltype == expected.ltype
+                assert error.rtype == expected.rtype
+            case StateInitNotInValues():
+                assert error.id == expected.id
+                assert error.line == expected.line
+                assert error.column == expected.column
+                assert error.values == expected.values
+            case StateArraySizeError():
+                assert error.id == expected.id
+                assert error.line == expected.line
+                assert error.column == expected.column
+                assert error.expected_size == expected.expected_size
+                assert error.actual_size == expected.actual_size
 
     # @staticmethod
     # def generate_promela(state: "State") -> Result[str, Error]:

--- a/test/core/test_typechecking.py
+++ b/test/core/test_typechecking.py
@@ -1,6 +1,8 @@
 # type: ignore
 import pytest
-from returns.result import Failure, Success
+from returns.functions import not_
+from returns.pipeline import is_successful
+from returns.result import Success
 
 from bpmncwpverify.core.error import TypingAssignCompatabilityError, TypingNoTypeError
 from bpmncwpverify.core.typechecking import (
@@ -58,8 +60,11 @@ class Test_get_type_assign:
         result = get_type_assign(ltype, rtype)
 
         # then
-        expected = Failure(TypingAssignCompatabilityError(ltype, rtype))
-        assert expected == result
+        assert not_(is_successful)(result)
+        error = result.failure()
+        assert isinstance(error, TypingAssignCompatabilityError)
+        assert error.ltype == ltype
+        assert error.rtype == rtype
 
 
 class Test_get_type_literal:
@@ -101,11 +106,12 @@ class Test_get_type_literal:
     )
     def test_given_bad_literal_then_failure(self, literal: str):
         # givin
-        literal = literal
+        # literal
 
         # when
         result = get_type_literal(literal)
 
-        # then
-        expected = Failure(TypingNoTypeError(literal))
-        assert expected == result
+        assert not_(is_successful)(result)
+        error = result.failure()
+        assert isinstance(error, TypingNoTypeError)
+        assert error.id == literal


### PR DESCRIPTION
I spent a while looking through the codebase and couldn't identify anywhere that errors were being compared except for the tests, so I removed the __eq__ methods from the errors and then updated the tests that were failing.

Will close #375 